### PR TITLE
resolve runner classes from core library namespace first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.26] - 2026-03-25
+
+### Added
+- `core_library_runner` private method in `PhaseWiring` — checks `Legion::` namespace directly before falling through to `Legion::Extensions`
+- `resolve_runner_class` now resolves core library runners (e.g., `Legion::Apollo::Runners::Request`) first, enabling GAIA phases to wire against the `legion-apollo` core gem without requiring `lex-apollo` to be co-located
+- Added `legion-apollo >= 0.2.1` to gemspec dependencies alongside existing `lex-apollo` dep
+
 ## [0.9.25] - 2026-03-25
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'legion-apollo', path: '../legion-apollo'
+
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/legion-gaia.gemspec
+++ b/legion-gaia.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'lex-privatecore'
 
   # PHASE_MAP operational extensions (required for full tick cycle)
+  spec.add_dependency 'legion-apollo', '>= 0.2.1'
   spec.add_dependency 'lex-apollo'
   spec.add_dependency 'lex-coldstart'
   spec.add_dependency 'lex-detect'

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -111,10 +111,32 @@ module Legion
       end
 
       def resolve_runner_class(ext_sym, runner_sym)
+        # Check core library namespace first (e.g., Legion::Apollo)
+        core = core_library_runner(ext_sym, runner_sym)
+        return core if core
+
+        # Then check extensions namespace
         ext_mod = locate_ext_mod(ext_sym)
         return flat_runner(ext_mod, runner_sym) || subdomain_runner(ext_mod, runner_sym) if ext_mod
 
         deep_agentic_runner(ext_sym, runner_sym)
+      end
+
+      def core_library_runner(ext_sym, runner_sym)
+        return nil unless Legion.const_defined?(ext_sym, false)
+
+        mod = Legion.const_get(ext_sym, false)
+        return nil unless mod.is_a?(Module)
+
+        # Check flat runners (e.g., Legion::Apollo::Runners::Request)
+        if mod.const_defined?(:Runners, false)
+          runners_mod = mod.const_get(:Runners, false)
+          return runners_mod.const_get(runner_sym, false) if runners_mod.const_defined?(runner_sym, false)
+        end
+
+        nil
+      rescue StandardError
+        nil
       end
 
       def deep_agentic_runner(ext_sym, runner_sym)

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.25'
+    VERSION = '0.9.26'
   end
 end

--- a/spec/legion/gaia/phase_wiring_spec.rb
+++ b/spec/legion/gaia/phase_wiring_spec.rb
@@ -97,6 +97,31 @@ RSpec.describe Legion::Gaia::PhaseWiring do
     it 'returns nil for missing extensions' do
       expect(described_class.resolve_runner_class(:Nonexistent, :Foo)).to be_nil
     end
+
+    context 'when core library module exists at Legion:: namespace' do
+      before do
+        stub_const('Legion::Apollo', Module.new)
+        stub_const('Legion::Apollo::Runners', Module.new)
+        stub_const('Legion::Apollo::Runners::Request', Class.new)
+      end
+
+      it 'resolves from core namespace first' do
+        result = described_class.resolve_runner_class(:Apollo, :Request)
+        expect(result).to eq(Legion::Apollo::Runners::Request)
+      end
+    end
+
+    context 'when core library exists but requested runner does not' do
+      before do
+        stub_const('Legion::Apollo', Module.new)
+        stub_const('Legion::Apollo::Runners', Module.new)
+      end
+
+      it 'falls through to extensions namespace' do
+        result = described_class.resolve_runner_class(:Apollo, :Nonexistent)
+        expect(result).to be_nil
+      end
+    end
   end
 
   describe '.discover_available_extensions' do


### PR DESCRIPTION
## Summary
- `resolve_runner_class` checks `Legion::` core namespace before `Legion::Extensions::`
- New `core_library_runner` private method
- `legion-apollo >= 0.2.1` added as gemspec dependency

## Changes
- `lib/legion/gaia/phase_wiring.rb` — core namespace resolution
- `legion-gaia.gemspec` — legion-apollo dependency
- 1 commit, version 0.9.25 → 0.9.26

## Test Coverage
- 394 examples, 0 failures
- `bundle exec rubocop` — zero offenses