### PR TITLE
fix ci: guard legion-apollo local path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'legion-apollo', path: '../legion-apollo'
+gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
 
 gem 'rake'
 gem 'rspec'


### PR DESCRIPTION
## Summary
- Add `if File.exist?` guard to the `legion-apollo` local path gem in Gemfile
- Fixes CI failure: `The path '/home/runner/work/legion-gaia/legion-apollo' does not exist`
- Matches the pattern used in LegionIO's Gemfile for all local path deps
- The gemspec `add_dependency 'legion-apollo'` ensures RubyGems resolution in CI

Closes the CI failure at https://github.com/LegionIO/legion-gaia/actions/runs/23570111320