### PR TITLE
implement wire format phase 3 group 3: bond registry rename and gaia uuid migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.9.46] - 2026-04-06
+
+### Changed
+- BondRegistry: rename `role:` kwarg to `bond:` with backward-compat alias (`role:` accepted, `#role` delegates to `#bond`)
+- BondRegistry: replace plain Hash with `Concurrent::Hash` for thread safety; remove lazy `@bonds ||= {}` init guards
+- BondRegistry: stored hash entries now carry both `:bond` and `:role` keys during migration window
+- BondRegistry: `hydrate_from_apollo` uses `bond:` kwarg internally; call sites updated to use `.bond` method
+- `extract_identity` in `gaia.rb` and `router_bridge.rb`: prefer `principal_id` before `aad_object_id` (dual-read §9.3)
+- `observe_interlocutor`: calls `BondRegistry.bond` instead of `BondRegistry.role`
+- `ProactiveDispatcher`: reads `b[:bond]` instead of `b[:role]` when scanning all_bonds for partner
+- `AuditObserver`: dual-read identity extraction — prefers `:identity`, falls back to `:id` (§9.4)
+- `SessionStore`: UUID detection via `/\A[0-9a-f]{8}-/i`, string identities normalized to lowercase; `find_or_create` gains `canonical_name:` kwarg for session migration; `@canonical_to_uuid` reverse index added; `remove_unlocked` cleans up all index entries for removed session
+- Add `concurrent-ruby >= 1.2` to gemspec dependencies
+
 ## [0.9.45] - 2026-04-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repository Level 3 Documentation**
 - **Parent**: `/Users/miverso2/rubymine/legion/CLAUDE.md`
 - **GitHub**: https://github.com/LegionIO/legion-gaia
-- **Version**: 0.9.44
+- **Version**: 0.9.46
 
 ## Purpose
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cognitive coordination layer for the LegionIO framework. GAIA is the mind that inhabits the Legion body.
 
-**Version**: 0.9.44
+**Version**: 0.9.46
 
 GAIA sits on top of LegionIO's infrastructure and coordinates all agentic subordinate functions. It drives the tick cycle, manages extension discovery and wiring, and provides the channel abstraction for multi-interface communication.
 

--- a/legion-gaia.gemspec
+++ b/legion-gaia.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'base64'
+  spec.add_dependency 'concurrent-ruby', '>= 1.2'
   spec.add_dependency 'legion-json', '>= 1.2.0'
   spec.add_dependency 'legion-logging', '>= 1.5.0'
   spec.add_dependency 'legion-settings', '>= 1.3.12'

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -374,11 +374,14 @@ module Legion
         ctx = input_frame.auth_context
         return nil if ctx.nil? || ctx.empty?
 
-        ctx[:aad_object_id] || ctx[:identity] || ctx[:user_id]
+        ctx[:principal_id] ||
+          ctx[:aad_object_id] ||
+          ctx[:identity] ||
+          ctx[:user_id]
       end
 
       def observe_interlocutor(input_frame, identity)
-        role = BondRegistry.role(identity.to_s)
+        role = BondRegistry.bond(identity.to_s)
 
         observation = {
           identity: identity.to_s,

--- a/lib/legion/gaia/audit_observer.rb
+++ b/lib/legion/gaia/audit_observer.rb
@@ -24,7 +24,7 @@ module Legion
           record_tool_patterns(event)
           record_quality(event)
         end
-        identity = event.dig(:caller, :requested_by, :identity)
+        identity = extract_caller_identity(event)
         log.debug(
           'AuditObserver processed event ' \
           "identity=#{identity || 'unknown'} tools=#{Array(event[:tools_used]).size}"
@@ -62,8 +62,13 @@ module Legion
 
       private
 
+      def extract_caller_identity(event)
+        rb = event.dig(:caller, :requested_by) || {}
+        rb[:identity] || rb[:id]
+      end
+
       def record_routing_preference(event)
-        identity = event.dig(:caller, :requested_by, :identity)
+        identity = extract_caller_identity(event)
         return unless identity
 
         provider = event.dig(:routing, :provider)

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -1,33 +1,43 @@
 # frozen_string_literal: true
 
 require 'legion/logging/helper'
+require 'concurrent/hash'
 
 module Legion
   module Gaia
     module BondRegistry
       extend Legion::Logging::Helper
 
+      @bonds = Concurrent::Hash.new
+
       module_function
 
-      def register(identity, role:, priority: :normal)
-        @bonds ||= {}
-        @bonds[identity.to_s] = { identity: identity.to_s, role: role.to_sym, priority: priority.to_sym,
-                                  since: Time.now.utc }
-        log.info("BondRegistry registered identity=#{identity} role=#{role} priority=#{priority}")
+      def register(identity, bond: nil, role: nil, priority: :normal)
+        effective_bond = (bond || role || :unknown).to_sym
+        @bonds[identity.to_s] = {
+          identity: identity.to_s,
+          bond: effective_bond,
+          role: effective_bond,
+          priority: priority.to_sym,
+          since: Time.now.utc
+        }
+        log.info("BondRegistry registered identity=#{identity} bond=#{effective_bond} priority=#{priority}")
       end
 
-      def partner?(identity)
-        role(identity) == :partner
+      def bond(identity)
+        entry = @bonds[identity.to_s]
+        entry ? entry[:bond] : :unknown
       end
 
       def role(identity)
-        @bonds ||= {}
-        entry = @bonds[identity.to_s]
-        entry ? entry[:role] : :unknown
+        bond(identity)
+      end
+
+      def partner?(identity)
+        bond(identity) == :partner
       end
 
       def all_bonds
-        @bonds ||= {}
         @bonds.values
       end
 
@@ -44,7 +54,7 @@ module Legion
           identities = extract_identity_keys(content)
           priority = content.match?(/primary/i) ? :primary : :normal
 
-          identities.each { |id| register(id, role: :partner, priority: priority) }
+          identities.each { |id| register(id, bond: :partner, priority: priority) }
         end
         log.info("BondRegistry hydrated entries=#{result[:results].size}")
       rescue StandardError => e
@@ -52,7 +62,7 @@ module Legion
       end
 
       def reset!
-        @bonds = {}
+        @bonds = Concurrent::Hash.new
         log.debug('BondRegistry reset')
       end
 

--- a/lib/legion/gaia/proactive_dispatcher.rb
+++ b/lib/legion/gaia/proactive_dispatcher.rb
@@ -148,14 +148,14 @@ module Legion
       def resolve_partner_id
         return nil unless defined?(Legion::Gaia::BondRegistry)
 
-        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:role] == :partner }
+        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:bond] == :partner }
         bond&.dig(:identity)&.to_s
       end
 
       def resolve_partner_channel
         return nil unless defined?(Legion::Gaia::BondRegistry)
 
-        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:role] == :partner }
+        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:bond] == :partner }
         bond&.dig(:preferred_channel) || bond&.dig(:last_channel)
       end
 

--- a/lib/legion/gaia/router/router_bridge.rb
+++ b/lib/legion/gaia/router/router_bridge.rb
@@ -83,7 +83,8 @@ module Legion
         private
 
         def extract_identity(input_frame)
-          input_frame.auth_context[:aad_object_id] ||
+          input_frame.auth_context[:principal_id] ||
+            input_frame.auth_context[:aad_object_id] ||
             input_frame.auth_context[:identity] ||
             input_frame.auth_context[:user_id]
         end

--- a/lib/legion/gaia/session_store.rb
+++ b/lib/legion/gaia/session_store.rb
@@ -5,6 +5,8 @@ require 'securerandom'
 module Legion
   module Gaia
     class SessionStore
+      UUID_PATTERN = /\A[0-9a-f]{8}-/i
+
       Session = ::Data.define(:id, :identity, :channel_history, :created_at, :last_active_at) do
         def initialize(identity:, id: SecureRandom.uuid, channel_history: [],
                        created_at: Time.now.utc, last_active_at: Time.now.utc)
@@ -15,13 +17,16 @@ module Legion
       def initialize(ttl: 86_400)
         @sessions = {}
         @identity_index = {}
+        @canonical_to_uuid = {}
         @ttl = ttl
         @mutex = Mutex.new
       end
 
-      def find_or_create(identity:)
+      def find_or_create(identity:, canonical_name: nil)
         @mutex.synchronize do
-          session_id = @identity_index[identity]
+          normalized = normalize_identity(identity)
+          session_id = resolve_session_id(normalized, canonical_name: canonical_name)
+
           if session_id && @sessions[session_id]
             session = @sessions[session_id]
             return session unless expired?(session)
@@ -29,9 +34,10 @@ module Legion
             remove_unlocked(session_id)
           end
 
-          session = Session.new(identity: identity)
+          session = Session.new(identity: normalized)
           @sessions[session.id] = session
-          @identity_index[identity] = session.id
+          @identity_index[normalized] = session.id
+          @canonical_to_uuid[canonical_name.to_s.downcase] = normalized if canonical_name && uuid?(normalized)
           session
         end
       end
@@ -76,13 +82,44 @@ module Legion
 
       private
 
+      def uuid?(identity)
+        UUID_PATTERN.match?(identity.to_s)
+      end
+
+      def normalize_identity(identity)
+        str = identity.to_s
+        uuid?(str) ? str : str.downcase
+      end
+
+      def resolve_session_id(normalized_identity, canonical_name:)
+        existing = @identity_index[normalized_identity]
+        return existing if existing
+
+        return nil unless canonical_name && uuid?(normalized_identity)
+
+        canonical_key = canonical_name.to_s.downcase
+        # Check if there is an existing string-keyed session for this canonical_name
+        old_session_id = @identity_index[canonical_key]
+        return nil unless old_session_id && @sessions[old_session_id]
+
+        # Migrate string-keyed session to UUID key
+        @identity_index.delete(canonical_key)
+        @identity_index[normalized_identity] = old_session_id
+        @canonical_to_uuid[canonical_key] = normalized_identity
+        old_session_id
+      end
+
       def expired?(session)
         (Time.now.utc - session.last_active_at) > @ttl
       end
 
       def remove_unlocked(session_id)
         session = @sessions.delete(session_id)
-        @identity_index.delete(session.identity) if session
+        if session
+          removed_keys = @identity_index.select { |_, v| v == session_id }.keys
+          removed_keys.each { |k| @identity_index.delete(k) }
+          @canonical_to_uuid.delete_if { |_, v| removed_keys.include?(v) }
+        end
         session
       end
     end

--- a/lib/legion/gaia/session_store.rb
+++ b/lib/legion/gaia/session_store.rb
@@ -5,7 +5,7 @@ require 'securerandom'
 module Legion
   module Gaia
     class SessionStore
-      UUID_PATTERN = /\A[0-9a-f]{8}-/i
+      UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
       Session = ::Data.define(:id, :identity, :channel_history, :created_at, :last_active_at) do
         def initialize(identity:, id: SecureRandom.uuid, channel_history: [],
@@ -18,6 +18,7 @@ module Legion
         @sessions = {}
         @identity_index = {}
         @canonical_to_uuid = {}
+        @session_identity_index = {}
         @ttl = ttl
         @mutex = Mutex.new
       end
@@ -37,6 +38,7 @@ module Legion
           session = Session.new(identity: normalized)
           @sessions[session.id] = session
           @identity_index[normalized] = session.id
+          @session_identity_index[session.id] = [normalized]
           @canonical_to_uuid[canonical_name.to_s.downcase] = normalized if canonical_name && uuid?(normalized)
           session
         end
@@ -102,10 +104,13 @@ module Legion
         old_session_id = @identity_index[canonical_key]
         return nil unless old_session_id && @sessions[old_session_id]
 
-        # Migrate string-keyed session to UUID key
-        @identity_index.delete(canonical_key)
+        # Migrate string-keyed session to UUID key.
+        # Keep the canonical string key in @identity_index so callers still
+        # using the old string identity continue to resolve the same session
+        # during the migration window.
         @identity_index[normalized_identity] = old_session_id
         @canonical_to_uuid[canonical_key] = normalized_identity
+        (@session_identity_index[old_session_id] ||= []) << normalized_identity
         old_session_id
       end
 
@@ -116,9 +121,10 @@ module Legion
       def remove_unlocked(session_id)
         session = @sessions.delete(session_id)
         if session
-          removed_keys = @identity_index.select { |_, v| v == session_id }.keys
+          removed_keys = @session_identity_index.delete(session_id) || []
           removed_keys.each { |k| @identity_index.delete(k) }
-          @canonical_to_uuid.delete_if { |_, v| removed_keys.include?(v) }
+          uuid_set = removed_keys.to_set
+          @canonical_to_uuid.delete_if { |_, v| uuid_set.include?(v) }
         end
         session
       end

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.45'
+    VERSION = '0.9.46'
   end
 end

--- a/spec/legion/gaia/audit_observer_spec.rb
+++ b/spec/legion/gaia/audit_observer_spec.rb
@@ -75,4 +75,44 @@ RSpec.describe Legion::Gaia::AuditObserver do
       expect(described_class.instance.user_preferences('user:matt')).to eq({})
     end
   end
+
+  describe 'dual-read identity extraction (§9.4)' do
+    it 'uses :identity when :id is absent' do
+      event = {
+        caller: { requested_by: { identity: 'user:matt' } },
+        routing: { provider: :anthropic },
+        tools_used: [], timestamp: Time.now
+      }
+      described_class.instance.process_event(event)
+      prefs = described_class.instance.user_preferences('user:matt')
+      expect(prefs[:routing]).to include(provider: :anthropic)
+    end
+
+    it 'uses :identity over :id for canonical_name key (preference key stability)' do
+      event = {
+        caller: { requested_by: { identity: 'user:matt', id: 'some-uuid-1234' } },
+        routing: { provider: :anthropic },
+        tools_used: [], timestamp: Time.now
+      }
+      described_class.instance.process_event(event)
+      prefs = described_class.instance.user_preferences('user:matt')
+      expect(prefs[:routing]).to include(provider: :anthropic)
+    end
+
+    it 'falls back to :id when :identity is absent' do
+      event = {
+        caller: { requested_by: { id: 'fallback-uuid-5678' } },
+        routing: { provider: :openai },
+        tools_used: [], timestamp: Time.now
+      }
+      described_class.instance.process_event(event)
+      prefs = described_class.instance.user_preferences('fallback-uuid-5678')
+      expect(prefs[:routing]).to include(provider: :openai)
+    end
+
+    it 'does not error when caller is absent' do
+      event = { routing: { provider: :anthropic }, tools_used: [], timestamp: Time.now }
+      expect { described_class.instance.process_event(event) }.not_to raise_error
+    end
+  end
 end

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -4,15 +4,73 @@ RSpec.describe Legion::Gaia::BondRegistry do
   before { described_class.reset! }
 
   describe '.register' do
-    it 'registers a bond with role and priority' do
-      described_class.register('esity', role: :partner, priority: :primary)
+    context 'with bond: kwarg (new API)' do
+      it 'registers a bond and stores :bond key' do
+        described_class.register('esity', bond: :partner, priority: :primary)
+        expect(described_class.bond('esity')).to eq(:partner)
+      end
+
+      it 'also stores :role key for backward compatibility' do
+        described_class.register('esity', bond: :partner, priority: :primary)
+        bond_entry = described_class.all_bonds.find { |b| b[:identity] == 'esity' }
+        expect(bond_entry[:role]).to eq(:partner)
+      end
+    end
+
+    context 'with role: kwarg (backward-compat alias)' do
+      it 'accepts role: and stores bond correctly' do
+        described_class.register('esity', role: :partner, priority: :primary)
+        expect(described_class.bond('esity')).to eq(:partner)
+      end
+
+      it 'stores both :bond and :role keys' do
+        described_class.register('esity', role: :partner, priority: :primary)
+        bond_entry = described_class.all_bonds.find { |b| b[:identity] == 'esity' }
+        expect(bond_entry[:bond]).to eq(:partner)
+        expect(bond_entry[:role]).to eq(:partner)
+      end
+    end
+
+    context 'with both bond: and role: provided' do
+      it 'bond: takes precedence over role:' do
+        described_class.register('esity', bond: :partner, role: :known, priority: :normal)
+        expect(described_class.bond('esity')).to eq(:partner)
+      end
+    end
+
+    context 'with neither bond: nor role: provided' do
+      it 'defaults to :unknown' do
+        described_class.register('esity')
+        expect(described_class.bond('esity')).to eq(:unknown)
+      end
+    end
+  end
+
+  describe '.bond' do
+    it 'returns :unknown for unregistered identities' do
+      expect(described_class.bond('nobody')).to eq(:unknown)
+    end
+
+    it 'returns the registered bond' do
+      described_class.register('esity', bond: :partner, priority: :primary)
+      expect(described_class.bond('esity')).to eq(:partner)
+    end
+  end
+
+  describe '.role (backward-compat alias)' do
+    it 'delegates to .bond' do
+      described_class.register('esity', bond: :partner, priority: :primary)
       expect(described_class.role('esity')).to eq(:partner)
+    end
+
+    it 'returns :unknown for unregistered identities' do
+      expect(described_class.role('nobody')).to eq(:unknown)
     end
   end
 
   describe '.partner?' do
     it 'returns true for registered partners' do
-      described_class.register('esity', role: :partner, priority: :primary)
+      described_class.register('esity', bond: :partner, priority: :primary)
       expect(described_class.partner?('esity')).to be true
     end
 
@@ -21,34 +79,41 @@ RSpec.describe Legion::Gaia::BondRegistry do
     end
 
     it 'returns false for known non-partners' do
-      described_class.register('colleague', role: :known, priority: :normal)
+      described_class.register('colleague', bond: :known, priority: :normal)
       expect(described_class.partner?('colleague')).to be false
-    end
-  end
-
-  describe '.role' do
-    it 'returns :unknown for unregistered identities' do
-      expect(described_class.role('nobody')).to eq(:unknown)
-    end
-
-    it 'returns the registered role' do
-      described_class.register('esity', role: :partner, priority: :primary)
-      expect(described_class.role('esity')).to eq(:partner)
     end
   end
 
   describe '.all_bonds' do
     it 'returns all registered bonds' do
-      described_class.register('esity', role: :partner, priority: :primary)
-      described_class.register('other', role: :known, priority: :normal)
+      described_class.register('esity', bond: :partner, priority: :primary)
+      described_class.register('other', bond: :known, priority: :normal)
       bonds = described_class.all_bonds
       expect(bonds.size).to eq(2)
-      expect(bonds.first[:identity]).to eq('esity')
+      identities = bonds.map { |b| b[:identity] }
+      expect(identities).to include('esity', 'other')
+    end
+
+    it 'each entry contains :bond and :role keys' do
+      described_class.register('esity', bond: :partner, priority: :primary)
+      entry = described_class.all_bonds.first
+      expect(entry).to have_key(:bond)
+      expect(entry).to have_key(:role)
+    end
+  end
+
+  describe 'thread safety (@bonds is Concurrent::Hash)' do
+    it 'handles concurrent registrations without error' do
+      threads = Array.new(20) do |i|
+        Thread.new { described_class.register("user_#{i}", bond: :known) }
+      end
+      threads.each(&:join)
+      expect(described_class.all_bonds.size).to eq(20)
     end
   end
 
   describe '.hydrate_from_apollo' do
-    it 'loads partner identities from Apollo Local seed data' do
+    it 'loads partner identities from Apollo Local seed data using bond:' do
       stub_apollo = double('Apollo::Local')
       seed_content = "Identity keys: esity, miverso2\nBond type: partner, creator\nBond priority: primary"
       allow(stub_apollo).to receive(:query).and_return(
@@ -67,9 +132,9 @@ RSpec.describe Legion::Gaia::BondRegistry do
   end
 
   describe 'multiple identity keys for same partner' do
-    it 'maps multiple identities to the same role' do
-      described_class.register('esity', role: :partner, priority: :primary)
-      described_class.register('miverso2', role: :partner, priority: :primary)
+    it 'maps multiple identities to the same bond' do
+      described_class.register('esity', bond: :partner, priority: :primary)
+      described_class.register('miverso2', bond: :partner, priority: :primary)
       expect(described_class.partner?('esity')).to be true
       expect(described_class.partner?('miverso2')).to be true
     end

--- a/spec/legion/gaia/calibration_integration_spec.rb
+++ b/spec/legion/gaia/calibration_integration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'GAIA calibration integration' do
       allow(Legion::Gaia).to receive(:started?).and_return(true)
       allow(Legion::Gaia).to receive(:log).and_return(double('Logger').as_null_object)
       allow(Legion::Gaia).to receive(:record_interaction_trace)
-      allow(Legion::Gaia::BondRegistry).to receive(:role).and_return(:partner)
+      allow(Legion::Gaia::BondRegistry).to receive(:bond).and_return(:partner)
       allow(Legion::Gaia::TrackerPersistence).to receive(:register_tracker)
       Legion::Gaia.instance_variable_set(:@partner_observations, [])
       Legion::Gaia.instance_variable_set(:@calibration_runner, nil)

--- a/spec/legion/gaia/proactive_dispatcher_spec.rb
+++ b/spec/legion/gaia/proactive_dispatcher_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
     context 'when partner bond has a preferred_channel' do
       before do
         allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { role: :partner,
+                                                                              { bond: :partner, role: :partner,
                                                                                 identity: 'esity',
                                                                                 preferred_channel: :teams }
                                                                             ])
@@ -170,7 +170,7 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
     context 'when partner bond has a last_channel but no preferred_channel' do
       before do
         allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { role: :partner,
+                                                                              { bond: :partner, role: :partner,
                                                                                 identity: 'esity',
                                                                                 last_channel: :slack }
                                                                             ])
@@ -184,7 +184,7 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
     context 'when non-partner bond exists but no partner bond' do
       before do
         allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { role: :colleague,
+                                                                              { bond: :colleague, role: :colleague,
                                                                                 identity: 'someone',
                                                                                 preferred_channel: :cli }
                                                                             ])

--- a/spec/legion/gaia/session_store_spec.rb
+++ b/spec/legion/gaia/session_store_spec.rb
@@ -21,6 +21,57 @@ RSpec.describe Legion::Gaia::SessionStore do
       b = store.find_or_create(identity: 'bob')
       expect(a.id).not_to eq(b.id)
     end
+
+    context 'UUID-based identity' do
+      let(:uuid) { '3f6c1234-0000-0000-0000-000000000000' }
+
+      it 'uses UUID directly without downcasing' do
+        session = store.find_or_create(identity: uuid)
+        expect(session.identity).to eq(uuid)
+      end
+
+      it 'returns same session on repeated lookup by UUID' do
+        first = store.find_or_create(identity: uuid)
+        second = store.find_or_create(identity: uuid)
+        expect(second.id).to eq(first.id)
+      end
+    end
+
+    context 'string identity normalization' do
+      it 'downcases string identities' do
+        session = store.find_or_create(identity: 'Alice')
+        expect(session.identity).to eq('alice')
+      end
+
+      it 'looks up case-insensitively by canonical name' do
+        first = store.find_or_create(identity: 'Alice')
+        second = store.find_or_create(identity: 'alice')
+        expect(second.id).to eq(first.id)
+      end
+    end
+
+    context 'UUID migration with canonical_name' do
+      let(:uuid) { 'a1b2c3d4-0000-0000-0000-000000000001' }
+
+      it 'migrates a string-keyed session to UUID key' do
+        string_session = store.find_or_create(identity: 'esity')
+        uuid_session = store.find_or_create(identity: uuid, canonical_name: 'esity')
+        expect(uuid_session.id).to eq(string_session.id)
+      end
+
+      it 'stores the UUID under identity index after migration' do
+        store.find_or_create(identity: 'esity')
+        store.find_or_create(identity: uuid, canonical_name: 'esity')
+        # subsequent UUID lookup returns migrated session
+        third = store.find_or_create(identity: uuid)
+        expect(third).not_to be_nil
+      end
+
+      it 'creates new session if no string session exists to migrate' do
+        session = store.find_or_create(identity: uuid, canonical_name: 'esity')
+        expect(session.identity).to eq(uuid)
+      end
+    end
   end
 
   describe '#touch' do
@@ -58,6 +109,16 @@ RSpec.describe Legion::Gaia::SessionStore do
       store.remove(session.id)
       expect(store.get(session.id)).to be_nil
       expect(store.size).to eq(0)
+    end
+
+    it 'cleans up canonical_to_uuid reverse index on remove' do
+      uuid = 'b0b0b0b0-0000-0000-0000-000000000001'
+      string_session = store.find_or_create(identity: 'esity')
+      store.find_or_create(identity: uuid, canonical_name: 'esity')
+      store.remove(string_session.id)
+      # After remove, a fresh lookup should create a new session
+      fresh = store.find_or_create(identity: uuid)
+      expect(fresh.id).not_to eq(string_session.id)
     end
   end
 

--- a/spec/legion/gaia_spec.rb
+++ b/spec/legion/gaia_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Legion::Gaia do
 
   describe '.ingest with partner observation' do
     before do
-      allow(Legion::Gaia::BondRegistry).to receive(:role).and_return(:unknown)
+      allow(Legion::Gaia::BondRegistry).to receive(:bond).and_return(:unknown)
 
       described_class.instance_variable_set(:@started, true)
       described_class.instance_variable_set(:@sensory_buffer, Legion::Gaia::SensoryBuffer.new)
@@ -422,7 +422,7 @@ RSpec.describe Legion::Gaia do
     end
 
     it 'detects partner role from BondRegistry' do
-      allow(Legion::Gaia::BondRegistry).to receive(:role).with('esity').and_return(:partner)
+      allow(Legion::Gaia::BondRegistry).to receive(:bond).with('esity').and_return(:partner)
 
       frame = Legion::Gaia::InputFrame.new(
         content: 'hello',


### PR DESCRIPTION
## Summary

- **§8 BondRegistry Rename**: Renames `role:` kwarg to `bond:` with full backward-compat alias. `#role` delegates to `#bond`. Both `:bond` and `:role` keys stored in hash entries during migration window. Replaces plain Hash with `Concurrent::Hash` for thread safety and removes lazy `@bonds ||= {}` init guards. Updates all call sites in `gaia.rb`, `proactive_dispatcher.rb`, and `hydrate_from_apollo`.
- **§9 GAIA UUID Migration**: `extract_identity` in both `gaia.rb` and `router_bridge.rb` now prefers `principal_id` before `aad_object_id` (dual-read §9.3). `AuditObserver` dual-read extracts `:identity || :id` from `requested_by` (§9.4). `SessionStore` gains UUID detection (`/\A[0-9a-f]{8}-/i`), string identity lowercasing, `canonical_name:` kwarg for session migration, `@canonical_to_uuid` reverse index, and proper cleanup in `remove_unlocked` (§9.5). Channel-native identity kept separate from principal UUID for proactive delivery.
- Adds `concurrent-ruby >= 1.2` to gemspec.

## Test plan

- [ ] All 106 specs pass (rspec exit 0)
- [ ] Rubocop clean (exit 0, 2 auto-corrected)
- [ ] `BondRegistry.register('id', role: :partner)` still works (backward compat)
- [ ] `BondRegistry.register('id', bond: :partner)` works (new API)
- [ ] `BondRegistry.role('id')` still delegates to `.bond` (alias)
- [ ] Both `:bond` and `:role` keys present in stored hash entries
- [ ] Concurrent registrations don't race (thread safety test)
- [ ] `extract_identity` returns `principal_id` when present
- [ ] `SessionStore` migrates string-keyed session to UUID key when `canonical_name:` provided
- [ ] `AuditObserver` falls back to `:id` when `:identity` absent