### PR TITLE
implement wire format §9.6 channel-native vs principal identity split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.47] - 2026-04-07
+
+### Added
+- `BondRegistry.register` gains optional `channel_identity:` kwarg to store channel-native user IDs (Slack `U*`, Teams user ID) separate from principal UUID (§9.6)
+- `BondRegistry.channel_identity(identity)` method returns the channel-native ID for delivery, falling back to the stored `identity` when no explicit `channel_identity` was registered
+- `ProactiveDispatcher#resolve_partner_id` now routes via `BondRegistry.channel_identity` so proactive delivery sends to channel-native IDs rather than principal UUIDs; prevents channel API failures when the bond was registered with a UUID principal
+
 ## [0.9.46] - 2026-04-06
 
 ### Changed

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -56,15 +56,17 @@ module Legion
       # Returns the single best partner bond entry using deterministic selection:
       #   1. Prefer entries that have an explicit channel_identity stored (§9.6 guarantee)
       #   2. Then prefer entries with priority: :primary
-      #   3. Otherwise return the first partner entry found
-      # This avoids non-deterministic delivery when multiple partner identities are registered.
+      #   3. Otherwise return the earliest-registered entry (sort by :since, then :identity)
+      # Sorting by :since then :identity ensures a stable result regardless of Concurrent::Hash
+      # enumeration order, which is not guaranteed.
       def partner_entry
         partners = @bonds.values.select { |b| b[:bond] == :partner }
         return nil if partners.empty?
 
-        partners.find { |b| b[:channel_identity] } ||
-          partners.find { |b| b[:priority] == :primary } ||
-          partners.first
+        sorted = partners.sort_by { |b| [b[:since], b[:identity]] }
+        sorted.find { |b| b[:channel_identity] } ||
+          sorted.find { |b| b[:priority] == :primary } ||
+          sorted.first
       end
 
       def hydrate_from_apollo(store: nil)

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -12,14 +12,15 @@ module Legion
 
       module_function
 
-      def register(identity, bond: nil, role: nil, priority: :normal)
+      def register(identity, bond: nil, role: nil, priority: :normal, channel_identity: nil)
         effective_bond = (bond || role || :unknown).to_sym
         @bonds[identity.to_s] = {
           identity: identity.to_s,
           bond: effective_bond,
           role: effective_bond,
           priority: priority.to_sym,
-          since: Time.now.utc
+          since: Time.now.utc,
+          channel_identity: channel_identity&.to_s
         }
         log.info("BondRegistry registered identity=#{identity} bond=#{effective_bond} priority=#{priority}")
       end
@@ -31,6 +32,17 @@ module Legion
 
       def role(identity)
         bond(identity)
+      end
+
+      # Returns the channel-native identity for the given principal identity.
+      # Falls back to the principal identity itself when no channel_identity was stored.
+      # Proactive delivery paths MUST use this method to avoid sending messages
+      # to a UUID that channel APIs (Teams, Slack) do not recognize.
+      def channel_identity(identity)
+        entry = @bonds[identity.to_s]
+        return nil unless entry
+
+        entry[:channel_identity] || entry[:identity]
       end
 
       def partner?(identity)

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -53,6 +53,20 @@ module Legion
         @bonds.values
       end
 
+      # Returns the single best partner bond entry using deterministic selection:
+      #   1. Prefer entries that have an explicit channel_identity stored (§9.6 guarantee)
+      #   2. Then prefer entries with priority: :primary
+      #   3. Otherwise return the first partner entry found
+      # This avoids non-deterministic delivery when multiple partner identities are registered.
+      def partner_entry
+        partners = @bonds.values.select { |b| b[:bond] == :partner }
+        return nil if partners.empty?
+
+        partners.find { |b| b[:channel_identity] } ||
+          partners.find { |b| b[:priority] == :primary } ||
+          partners.first
+      end
+
       def hydrate_from_apollo(store: nil)
         return unless store
 

--- a/lib/legion/gaia/proactive_dispatcher.rb
+++ b/lib/legion/gaia/proactive_dispatcher.rb
@@ -149,7 +149,12 @@ module Legion
         return nil unless defined?(Legion::Gaia::BondRegistry)
 
         bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:bond] == :partner }
-        bond&.dig(:identity)&.to_s
+        return nil unless bond
+
+        # Use channel_identity when present (§9.6): channel APIs (Teams, Slack) need
+        # channel-native user IDs, not principal UUIDs. Falls back to :identity for
+        # entries registered without an explicit channel_identity.
+        Legion::Gaia::BondRegistry.channel_identity(bond[:identity])
       end
 
       def resolve_partner_channel

--- a/lib/legion/gaia/proactive_dispatcher.rb
+++ b/lib/legion/gaia/proactive_dispatcher.rb
@@ -148,19 +148,20 @@ module Legion
       def resolve_partner_id
         return nil unless defined?(Legion::Gaia::BondRegistry)
 
-        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:bond] == :partner }
+        # Use partner_entry for deterministic selection when multiple partner bonds exist
+        # (§9.6): prefers entries with channel_identity, then primary priority, then first.
+        bond = Legion::Gaia::BondRegistry.partner_entry
         return nil unless bond
 
-        # Use channel_identity when present (§9.6): channel APIs (Teams, Slack) need
-        # channel-native user IDs, not principal UUIDs. Falls back to :identity for
-        # entries registered without an explicit channel_identity.
+        # Use channel_identity when present: channel APIs (Teams, Slack) need
+        # channel-native user IDs, not principal UUIDs. Falls back to :identity.
         Legion::Gaia::BondRegistry.channel_identity(bond[:identity])
       end
 
       def resolve_partner_channel
         return nil unless defined?(Legion::Gaia::BondRegistry)
 
-        bond = Legion::Gaia::BondRegistry.all_bonds.find { |b| b[:bond] == :partner }
+        bond = Legion::Gaia::BondRegistry.partner_entry
         bond&.dig(:preferred_channel) || bond&.dig(:last_channel)
       end
 

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.46'
+    VERSION = '0.9.47'
   end
 end

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -139,4 +139,33 @@ RSpec.describe Legion::Gaia::BondRegistry do
       expect(described_class.partner?('miverso2')).to be true
     end
   end
+
+  describe '.channel_identity (§9.6)' do
+    it 'returns the stored channel_identity when present' do
+      described_class.register('a1b2c3d4-0000-0000-0000-aabbccddeeff',
+                               bond: :partner, channel_identity: 'U12345')
+      expect(described_class.channel_identity('a1b2c3d4-0000-0000-0000-aabbccddeeff')).to eq('U12345')
+    end
+
+    it 'falls back to :identity when no channel_identity was stored' do
+      described_class.register('esity', bond: :partner, priority: :primary)
+      expect(described_class.channel_identity('esity')).to eq('esity')
+    end
+
+    it 'returns nil for unregistered identities' do
+      expect(described_class.channel_identity('nobody')).to be_nil
+    end
+
+    it 'stores channel_identity in the bond hash entry' do
+      described_class.register('uuid-1', bond: :partner, channel_identity: 'T09876')
+      entry = described_class.all_bonds.find { |b| b[:identity] == 'uuid-1' }
+      expect(entry[:channel_identity]).to eq('T09876')
+    end
+
+    it 'stores nil channel_identity when not provided' do
+      described_class.register('esity', bond: :partner)
+      entry = described_class.all_bonds.find { |b| b[:identity] == 'esity' }
+      expect(entry[:channel_identity]).to be_nil
+    end
+  end
 end

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -140,6 +140,39 @@ RSpec.describe Legion::Gaia::BondRegistry do
     end
   end
 
+  describe '.partner_entry (§9.6 deterministic selection)' do
+    it 'returns nil when no partner bonds exist' do
+      described_class.register('colleague', bond: :known)
+      expect(described_class.partner_entry).to be_nil
+    end
+
+    it 'returns the single partner entry when only one exists' do
+      described_class.register('esity', bond: :partner)
+      expect(described_class.partner_entry[:identity]).to eq('esity')
+    end
+
+    it 'prefers an entry with channel_identity over one without' do
+      described_class.register('uuid-primary', bond: :partner, priority: :primary)
+      described_class.register('uuid-channel', bond: :partner, channel_identity: 'U_SLACK_999')
+      entry = described_class.partner_entry
+      expect(entry[:identity]).to eq('uuid-channel')
+    end
+
+    it 'prefers priority :primary over :normal when neither has channel_identity' do
+      described_class.register('normal-id', bond: :partner, priority: :normal)
+      described_class.register('primary-id', bond: :partner, priority: :primary)
+      entry = described_class.partner_entry
+      expect(entry[:identity]).to eq('primary-id')
+    end
+
+    it 'falls back to first entry when no channel_identity or primary priority match' do
+      described_class.register('first-id', bond: :partner, priority: :normal)
+      described_class.register('second-id', bond: :partner, priority: :normal)
+      entry = described_class.partner_entry
+      expect(%w[first-id second-id]).to include(entry[:identity])
+    end
+  end
+
   describe '.channel_identity (§9.6)' do
     it 'returns the stored channel_identity when present' do
       described_class.register('a1b2c3d4-0000-0000-0000-aabbccddeeff',

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -165,11 +165,13 @@ RSpec.describe Legion::Gaia::BondRegistry do
       expect(entry[:identity]).to eq('primary-id')
     end
 
-    it 'falls back to first entry when no channel_identity or primary priority match' do
-      described_class.register('first-id', bond: :partner, priority: :normal)
+    it 'falls back to earliest-registered entry when no channel_identity or primary priority match' do
       described_class.register('second-id', bond: :partner, priority: :normal)
+      sleep(0.001)
+      described_class.register('first-id', bond: :partner, priority: :normal)
       entry = described_class.partner_entry
-      expect(%w[first-id second-id]).to include(entry[:identity])
+      # 'second-id' registered first (:since is earlier), so it wins the tie-breaker
+      expect(entry[:identity]).to eq('second-id')
     end
   end
 

--- a/spec/legion/gaia/proactive_dispatcher_spec.rb
+++ b/spec/legion/gaia/proactive_dispatcher_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
 
     context 'when BondRegistry has no partner bond' do
       before do
-        allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([])
+        allow(Legion::Gaia::BondRegistry).to receive(:partner_entry).and_return(nil)
       end
 
       it 'returns nil' do
@@ -204,11 +204,9 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
 
     context 'when partner bond has a preferred_channel' do
       before do
-        allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { bond: :partner, role: :partner,
-                                                                                identity: 'esity',
-                                                                                preferred_channel: :teams }
-                                                                            ])
+        allow(Legion::Gaia::BondRegistry).to receive(:partner_entry).and_return(
+          { bond: :partner, role: :partner, identity: 'esity', preferred_channel: :teams }
+        )
       end
 
       it 'returns the preferred_channel' do
@@ -218,11 +216,9 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
 
     context 'when partner bond has a last_channel but no preferred_channel' do
       before do
-        allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { bond: :partner, role: :partner,
-                                                                                identity: 'esity',
-                                                                                last_channel: :slack }
-                                                                            ])
+        allow(Legion::Gaia::BondRegistry).to receive(:partner_entry).and_return(
+          { bond: :partner, role: :partner, identity: 'esity', last_channel: :slack }
+        )
       end
 
       it 'falls back to last_channel' do
@@ -230,17 +226,30 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
       end
     end
 
-    context 'when non-partner bond exists but no partner bond' do
+    context 'when BondRegistry returns nil from partner_entry' do
       before do
-        allow(Legion::Gaia::BondRegistry).to receive(:all_bonds).and_return([
-                                                                              { bond: :colleague, role: :colleague,
-                                                                                identity: 'someone',
-                                                                                preferred_channel: :cli }
-                                                                            ])
+        allow(Legion::Gaia::BondRegistry).to receive(:partner_entry).and_return(nil)
       end
 
       it 'returns nil' do
         expect(dispatcher.send(:resolve_partner_channel)).to be_nil
+      end
+    end
+  end
+
+  describe '#resolve_partner_id with multiple partner bonds (§9.6 deterministic selection)' do
+    context 'when multiple partner bonds exist and one has channel_identity' do
+      let(:uuid) { 'a1b2c3d4-0000-0000-0000-preferred' }
+
+      before do
+        Legion::Gaia::BondRegistry.reset!
+        Legion::Gaia::BondRegistry.register('primary-only', bond: :partner, priority: :primary)
+        Legion::Gaia::BondRegistry.register(uuid, bond: :partner, channel_identity: 'U_PREFERRED')
+      end
+      after { Legion::Gaia::BondRegistry.reset! }
+
+      it 'selects the entry with channel_identity regardless of priority order' do
+        expect(dispatcher.send(:resolve_partner_id)).to eq('U_PREFERRED')
       end
     end
   end

--- a/spec/legion/gaia/proactive_dispatcher_spec.rb
+++ b/spec/legion/gaia/proactive_dispatcher_spec.rb
@@ -134,6 +134,55 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
     end
   end
 
+  describe '#resolve_partner_id (§9.6 channel-identity routing)' do
+    context 'when no partner bond is registered' do
+      before { Legion::Gaia::BondRegistry.reset! }
+      after  { Legion::Gaia::BondRegistry.reset! }
+
+      it 'returns nil' do
+        expect(dispatcher.send(:resolve_partner_id)).to be_nil
+      end
+    end
+
+    context 'when partner bond has no channel_identity' do
+      before do
+        Legion::Gaia::BondRegistry.reset!
+        Legion::Gaia::BondRegistry.register('esity', bond: :partner)
+      end
+      after { Legion::Gaia::BondRegistry.reset! }
+
+      it 'falls back to the identity string' do
+        expect(dispatcher.send(:resolve_partner_id)).to eq('esity')
+      end
+    end
+
+    context 'when partner bond has a channel_identity (UUID principal + channel-native ID)' do
+      let(:uuid) { 'a1b2c3d4-1111-0000-0000-000000000001' }
+
+      before do
+        Legion::Gaia::BondRegistry.reset!
+        Legion::Gaia::BondRegistry.register(uuid, bond: :partner, channel_identity: 'U_SLACK_123')
+      end
+      after { Legion::Gaia::BondRegistry.reset! }
+
+      it 'returns the channel-native identity for delivery' do
+        expect(dispatcher.send(:resolve_partner_id)).to eq('U_SLACK_123')
+      end
+
+      it 'does not return the principal UUID to channel APIs' do
+        expect(dispatcher.send(:resolve_partner_id)).not_to eq(uuid)
+      end
+    end
+
+    context 'when BondRegistry is not defined' do
+      before { hide_const('Legion::Gaia::BondRegistry') }
+
+      it 'returns nil' do
+        expect(dispatcher.send(:resolve_partner_id)).to be_nil
+      end
+    end
+  end
+
   describe '#resolve_partner_channel (Fix 6)' do
     context 'when BondRegistry is not defined' do
       before { hide_const('Legion::Gaia::BondRegistry') }


### PR DESCRIPTION
## Summary

- `BondRegistry.register` gains optional `channel_identity:` kwarg — callers can store channel-native user IDs (Slack `U*`, Teams user ID) separately from the principal UUID that `extract_identity` now returns
- `BondRegistry.channel_identity(identity)` method returns the stored channel-native ID, falling back to the stored `identity` when none was registered
- `ProactiveDispatcher#resolve_partner_id` now routes via `BondRegistry.channel_identity` — prevents proactive delivery from sending principal UUIDs to channel APIs (Teams, Slack) that only accept channel-native user IDs

## Context

This is §9.6 of the wire format identity design (`docs/plans/2026-04-06-wire-format-identity-design.md`). PR #22 implemented §9.1–9.5 (dual-read `extract_identity`, `AuditObserver`, `SessionStore` UUID migration, `BondRegistry` rename). §9.6 was the remaining unimplemented section — the critical proactive delivery fix to keep channel-native identity separate from principal UUID.

## Test plan

- [ ] `BondRegistry.register` accepts `channel_identity:` without error
- [ ] `BondRegistry.channel_identity` returns explicit channel ID when stored
- [ ] `BondRegistry.channel_identity` falls back to `identity` string when no explicit channel ID
- [ ] `ProactiveDispatcher#resolve_partner_id` returns channel-native ID when registered with UUID principal
- [ ] All existing bond registry, proactive dispatcher, and session store specs pass