### PR TITLE
fix: cache absence pattern check + wire 12 cognitive phases + gaia ingest API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.9.48] - 2026-04-23
+
+### Fixed
+- Cache `partner_absence_exceeds_pattern?` result with 60s TTL to stop Apollo::Local query loop — `reflect_on_bonds` was querying SQLite FTS twice per heartbeat tick (1/sec) with zero results, causing sustained high CPU load
+
+### Added
+- Wire 12 new cognitive phases into PHASE_MAP and PHASE_ARGS: `curiosity_execution`, `dream_cycle`, `creativity_tick`, `lucid_dream`, `epistemic_vigilance`, `predictive_processing`, `free_energy`, `metacognition`, `default_mode_network`, `prospective_memory`, `inner_speech`, `global_workspace`
+- Idle-skip guards on `social_cognition` and `theory_of_mind` — skip when no signals and no partner observations
+- `POST /api/gaia/ingest` REST endpoint for pushing content into the GAIA sensory buffer
+
 ## [0.9.47] - 2026-04-07
 
 ### Added

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -38,6 +38,7 @@ module Legion
     ABSENCE_SIGNAL_COOLDOWN  = 1800
     ABSENCE_SIGNAL_SALIENCE  = 0.75
     ABSENCE_SIGNAL_TEXT      = 'partner absence exceeded expected pattern'
+    ABSENCE_PATTERN_CACHE_TTL = 60
 
     class << self # rubocop:disable Metrics/ClassLength
       include Legion::Gaia::Logging
@@ -102,6 +103,8 @@ module Legion
         @partner_observations = nil
         @partner_absence_misses = 0
         @last_absence_signal_at = nil
+        @absence_pattern_cache = nil
+        @absence_pattern_checked_at = nil
         @last_valences = nil
         @last_response_at = nil
         @tick_history = nil
@@ -252,6 +255,8 @@ module Legion
         @partner_observations = []
         @partner_absence_misses = 0
         @last_absence_signal_at = nil
+        @absence_pattern_cache = nil
+        @absence_pattern_checked_at = nil
         @tick_history = TickHistory.new
         @tick_count = 0
         @started_at = Time.now.utc
@@ -541,11 +546,18 @@ module Legion
       end
 
       def partner_absence_exceeds_pattern?
+        if @absence_pattern_checked_at &&
+           (Time.now.utc - @absence_pattern_checked_at) < ABSENCE_PATTERN_CACHE_TTL
+          return @absence_pattern_cache == true
+        end
+
         runner = @registry&.runner_instances&.dig(:Social_Attachment)
         return false unless runner.respond_to?(:reflect_on_bonds)
 
         result = runner.reflect_on_bonds(tick_results: {}, bond_summary: {})
-        result.dig(:partner_bond, :absence_exceeds_pattern) == true
+        @absence_pattern_cache = result.dig(:partner_bond, :absence_exceeds_pattern) == true
+        @absence_pattern_checked_at = Time.now.utc
+        @absence_pattern_cache
       rescue StandardError => e
         handle_exception(e, level: :debug, operation: 'gaia.partner_absence_exceeds_pattern')
         false

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -37,6 +37,7 @@ module Legion
         association_walk: { ext: :Memory, runner: :Consolidation, fn: :hebbian_link },
         contradiction_resolution: { ext: :Conflict, runner: :Conflict, fn: :active_conflicts },
         agenda_formation: { ext: :Curiosity, runner: :Curiosity, fn: :form_agenda },
+        curiosity_execution: { ext: :Curiosity, runner: :Curiosity, fn: :self_inquire },
         consolidation_commit: { ext: :Memory, runner: :Consolidation, fn: :migrate_tier },
         knowledge_promotion: { ext: :Apollo, runner: :Knowledge, fn: :handle_ingest },
         dream_reflection: { ext: :Reflection, runner: :Reflection, fn: :reflect },
@@ -44,7 +45,33 @@ module Legion
           { ext: :Social, runner: :Attachment, fn: :reflect_on_bonds },
           { ext: :Social, runner: :Calibration, fn: :sync_partner_knowledge }
         ],
-        dream_narration: { ext: :Narrator, runner: :Narrator, fn: :narrate }
+        dream_narration: { ext: :Narrator, runner: :Narrator, fn: :narrate },
+
+        # lex-agentic-imagination
+        dream_cycle: { ext: :Dream,        runner: :DreamCycle, fn: :execute_dream_cycle },
+        creativity_tick: { ext: :Creativity, runner: :Creativity, fn: :creative_tick },
+        lucid_dream: { ext: :Lucidity, runner: :CognitiveLucidity, fn: :begin_dream },
+
+        # lex-agentic-defense
+        epistemic_vigilance: { ext: :EpistemicVigilance, runner: :EpistemicVigilance, fn: :assess_epistemic_claim },
+
+        # lex-agentic-inference
+        predictive_processing: { ext: :PredictiveProcessing, runner: :PredictiveProcessing, fn: :predict_from_model },
+        free_energy: { ext: :FreeEnergy, runner: :FreeEnergy, fn: :minimize_free_energy },
+
+        # lex-agentic-self
+        metacognition: { ext: :Metacognition, runner: :Metacognition, fn: :introspect },
+        default_mode_network: { ext: :DefaultModeNetwork, runner: :DefaultModeNetwork,
+                                fn: :generate_idle_thought },
+
+        # lex-agentic-executive
+        prospective_memory: { ext: :ProspectiveMemory, runner: :ProspectiveMemory, fn: :monitor_intention },
+
+        # lex-agentic-language
+        inner_speech: { ext: :InnerSpeech, runner: :InnerSpeech, fn: :inner_speak },
+
+        # lex-agentic-integration
+        global_workspace: { ext: :GlobalWorkspace, runner: :GlobalWorkspace, fn: :run_competition }
       }.freeze
 
       PHASE_ARGS = {
@@ -87,10 +114,20 @@ module Legion
         },
         mesh_interface: ->(_ctx) { {} },
         social_cognition: lambda { |ctx|
+          if Array(ctx[:signals]).empty? && partner_observations_from(ctx).empty?
+            return { skip: true,
+                     reason: :idle_no_signals }
+          end
+
           { tick_results: ctx[:prior_results] || {},
             human_observations: partner_observations_from(ctx) }
         },
         theory_of_mind: lambda { |ctx|
+          if Array(ctx[:signals]).empty? && partner_observations_from(ctx).empty?
+            return { skip: true,
+                     reason: :idle_no_signals }
+          end
+
           { tick_results: ctx[:prior_results] || {},
             human_observations: partner_observations_from(ctx) }
         },
@@ -115,6 +152,7 @@ module Legion
         },
         contradiction_resolution: ->(_ctx) { {} },
         agenda_formation: ->(_ctx) { {} },
+        curiosity_execution: ->(_ctx) { { max_wonders: 1 } },
         consolidation_commit: ->(_ctx) { {} },
         knowledge_promotion: lambda { |ctx|
           content = build_promotion_content(ctx[:prior_results] || {})
@@ -130,7 +168,36 @@ module Legion
         },
         dream_narration: lambda { |ctx|
           { tick_results: ctx[:prior_results] || {}, cognitive_state: { source: :dream } }
-        }
+        },
+
+        # lex-agentic-imagination
+        dream_cycle: ->(_ctx) { {} },
+        creativity_tick: ->(ctx)  { { tick_results: ctx[:prior_results] || {} } },
+        lucid_dream: ->(_ctx) { { theme: :reflection, content: 'autonomous dream cycle' } },
+
+        # lex-agentic-defense
+        epistemic_vigilance: ->(_ctx) { { claim_id: nil } },
+
+        # lex-agentic-inference
+        predictive_processing: lambda { |ctx|
+          { domain: ctx.dig(:prior_results, :memory_retrieval, :domain) || :general, context: {} }
+        },
+        free_energy: ->(_ctx) { { belief_id: nil, mode: :perceptual } },
+
+        # lex-agentic-self
+        metacognition: ->(ctx) { { tick_results: ctx[:prior_results] || {}, subsystem_states: {} } },
+        default_mode_network: ->(_ctx) { {} },
+
+        # lex-agentic-executive
+        prospective_memory: ->(_ctx) { { intention_id: nil } },
+
+        # lex-agentic-language
+        inner_speech: lambda { |ctx|
+          { content: ctx.dig(:prior_results, :action_selection, :goal).to_s, mode: :narrating, topic: :general }
+        },
+
+        # lex-agentic-integration
+        global_workspace: ->(_ctx) { {} }
       }.freeze
 
       @previous_reflection = {}

--- a/lib/legion/gaia/routes.rb
+++ b/lib/legion/gaia/routes.rb
@@ -61,6 +61,7 @@ module Legion
         register_buffer_route(app)
         register_sessions_route(app)
         register_teams_webhook_route(app)
+        register_ingest_route(app)
       end
 
       def self.register_status_route(app)
@@ -173,9 +174,35 @@ module Legion
         nil
       end
 
+      def self.register_ingest_route(app)
+        app.post '/api/gaia/ingest' do
+          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+
+          body = Legion::JSON.load(request.body.read)
+          content  = body[:content] || body['content']
+          identity = body[:identity] || body['identity'] || 'unknown'
+          channel  = (body[:channel_id] || body['channel_id'] || 'cli').to_sym
+
+          halt 400, json_error('missing_content', 'content is required', status_code: 400) if content.to_s.empty?
+
+          frame = Legion::Gaia::InputFrame.new(
+            content: content,
+            channel_id: channel,
+            content_type: :text,
+            auth_context: { identity: identity },
+            metadata: { source_type: :human_direct, salience: 0.8 }
+          )
+
+          Legion::Gaia.ingest(frame)
+          Legion::Logging.info "API: gaia ingest frame_id=#{frame.id} identity=#{identity}" if defined?(Legion::Logging)
+          json_response({ status: 'accepted', frame_id: frame.id })
+        end
+      end
+
       class << self
         private :register_status_route, :register_ticks_route, :register_channels_route,
-                :register_buffer_route, :register_sessions_route, :register_teams_webhook_route
+                :register_buffer_route, :register_sessions_route, :register_teams_webhook_route,
+                :register_ingest_route
       end
     end
   end

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.47'
+    VERSION = '0.9.48'
   end
 end

--- a/spec/legion/gaia/phase_wiring_spec.rb
+++ b/spec/legion/gaia/phase_wiring_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Legion::Gaia::PhaseWiring do
       end
     end
 
-    it 'has 25 total phases' do
-      expect(described_class::PHASE_MAP.size).to eq(25)
+    it 'has 37 total phases' do
+      expect(described_class::PHASE_MAP.size).to eq(37)
     end
 
     it 'each mapping has ext, runner, and fn keys' do
@@ -401,11 +401,12 @@ RSpec.describe Legion::Gaia::PhaseWiring do
       expect(result[:human_observations]).to eq([{ identity: 'esity' }])
     end
 
-    it 'defaults to empty array when no observations' do
+    it 'skips social_cognition when idle with no observations' do
       args_lambda = described_class::PHASE_ARGS[:social_cognition]
       ctx = { prior_results: {}, state: {}, signals: [], current_signal: nil, valences: {} }
       result = args_lambda.call(ctx)
-      expect(result[:human_observations]).to eq([])
+      expect(result[:skip]).to eq(true)
+      expect(result[:reason]).to eq(:idle_no_signals)
     end
   end
 


### PR DESCRIPTION
## Summary

- **Fix Apollo::Local query loop**: `partner_absence_exceeds_pattern?` called `reflect_on_bonds` on every heartbeat tick (1/sec) once absence misses exceeded 5, generating 2 Apollo::Local FTS queries per second that always returned 0 results. Added a 60-second TTL cache — drops query volume from ~120/min to ~2/min.
- **Wire 12 new cognitive phases**: `curiosity_execution`, `dream_cycle`, `creativity_tick`, `lucid_dream`, `epistemic_vigilance`, `predictive_processing`, `free_energy`, `metacognition`, `default_mode_network`, `prospective_memory`, `inner_speech`, `global_workspace` — PHASE_MAP + PHASE_ARGS entries for each.
- **Idle-skip guards**: `social_cognition` and `theory_of_mind` now skip when no signals and no partner observations.
- **`POST /api/gaia/ingest`**: REST endpoint for pushing content into the GAIA sensory buffer.
- Bump to v0.9.48, CHANGELOG updated, stale phase count spec fixed.

## Context

The query loop was visible as alternating `text_length=21` (`communication_pattern`) and `text_length=16` (`relationship_arc`) log lines firing ~4x/second, spiking CPU load to 6+ on an M4 Max. The 12 new phases and ingest route were staged locally but never committed.

## Test plan

- [x] 737/737 rspec examples pass (0 failures)
- [x] 106/106 rubocop files clean (0 offenses)
- [ ] Verify query rate drops from ~120/min to ~2/min in running daemon