### PR TITLE
Fix GAIA gap analysis findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Close the 2026-05-06 GAIA gap-analysis findings across advisory generation, Bot Framework JWT issuer validation, router outbound delivery, offline queuing, proactive partner channels, notification gating, Teams delivery, and shared-state synchronization.
 - Normalize advisory routing hints, support string-keyed tool predictions, and return a stable empty advisory hash when advisory generation fails.
 - Replace high-severity `log.unknown` message tracing with debug logging to avoid production PII log flooding.
+- Harden PR review follow-up behavior for outbound queue acknowledgements, delayed notification TTL preservation, atomic bond channel metadata updates, and adapter delivery-signature caching.
 
 ## [0.9.51] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.52] - 2026-05-07
+
+### Fixed
+- Close the 2026-05-06 GAIA gap-analysis findings across advisory generation, Bot Framework JWT issuer validation, router outbound delivery, offline queuing, proactive partner channels, notification gating, Teams delivery, and shared-state synchronization.
+- Normalize advisory routing hints, support string-keyed tool predictions, and return a stable empty advisory hash when advisory generation fails.
+- Replace high-severity `log.unknown` message tracing with debug logging to avoid production PII log flooding.
+
 ## [0.9.51] - 2026-04-27
 
 ### Fixed

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -206,6 +206,10 @@ module Legion
         session = @session_store&.find_or_create(identity: identity || :anonymous)
         @session_store&.touch(session.id, channel_id: input_frame.channel_id) if session
 
+        if identity
+          BondRegistry.record_channel(identity.to_s, channel_id: input_frame.channel_id,
+                                                     channel_identity: channel_identity(input_frame))
+        end
         observe_interlocutor(input_frame, identity) if identity && identity != :anonymous
 
         log.info(
@@ -387,8 +391,6 @@ module Legion
       end
 
       def boot_agent_bridge
-        return unless settings&.dig(:router, :mode)
-
         worker_id = settings&.dig(:router, :worker_id)
         return unless worker_id
 
@@ -499,6 +501,11 @@ module Legion
           ctx[:user_id]
       end
 
+      def channel_identity(input_frame)
+        ctx = input_frame.auth_context || {}
+        ctx[:channel_identity] || ctx[:user_id] || ctx[:identity]
+      end
+
       def observe_interlocutor(input_frame, identity)
         role = BondRegistry.bond(identity.to_s)
 
@@ -544,7 +551,7 @@ module Legion
           },
           domain_tags: ['partner_interaction', observation[:channel].to_s],
           origin: :direct_experience,
-          emotional_valence: @last_valences&.dig(0, :urgency).to_s,
+          emotional_valence: @last_valences&.first&.inspect,
           emotional_intensity: 0.5,
           confidence: 0.8
         )

--- a/lib/legion/gaia/advisory.rb
+++ b/lib/legion/gaia/advisory.rb
@@ -13,7 +13,7 @@ module Legion
       # Returns Hash with optional keys: system_prompt, routing_hint,
       # context_window, tool_hint, suppress, valence
       def advise(caller:, conversation_id: nil, messages: nil)
-        log.unknown "advise(caller: #{caller}, conversation_id: #{conversation_id}, messages: #{messages}) "
+        log.debug "advise(caller: #{caller}, conversation_id: #{conversation_id}, messages: #{messages}) "
         return nil unless Gaia.started?
 
         advisory = {}
@@ -27,17 +27,17 @@ module Legion
         result
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.advisory.advise', conversation_id: conversation_id)
-        nil
+        {}
       end
 
       def merge_tick_data!(advisory, tick_result)
-        log.unknown "merge_tick_data!(#{advisory.inspect}, #{tick_result})"
+        log.debug "merge_tick_data!(#{advisory.inspect}, #{tick_result})"
         return unless tick_result && tick_result[:results]
 
         results = tick_result[:results]
         apply_tool_hints!(advisory, results)
         apply_suppress!(advisory, results)
-        advisory[:routing_hint] = results.dig(:post_tick_reflection, :routing_preference)
+        advisory[:routing_hint] = normalize_routing_hint(results.dig(:post_tick_reflection, :routing_preference))
         advisory[:context_window] = results.dig(:memory_retrieval, :cross_conversation)
       end
 
@@ -45,7 +45,11 @@ module Legion
         predictions = results.dig(:prediction_engine, :predictions)
         return unless predictions
 
-        tools = predictions.select { |p| p[:confidence] >= 0.6 }.map { |p| p[:tool] }
+        tools = predictions.filter_map do |prediction|
+          confidence = value_for(prediction, :confidence).to_f
+          tool = value_for(prediction, :tool)
+          tool if confidence >= 0.6 && tool
+        end
         advisory[:tool_hint] = tools.empty? ? nil : tools
       end
 
@@ -62,11 +66,36 @@ module Legion
         return unless identity
 
         learned = AuditObserver.instance.learned_data_for(identity)
-        advisory[:routing_hint] ||= learned[:routing_preference] if learned[:routing_preference]
+        advisory[:routing_hint] ||= normalize_routing_hint(learned[:routing_preference]) if learned[:routing_preference]
         advisory[:tool_hint] ||= learned[:tool_predictions].keys.first(5) if learned[:tool_predictions]&.any?
       end
 
-      private_class_method :merge_tick_data!, :apply_tool_hints!, :apply_suppress!, :merge_observer_data!
+      def normalize_routing_hint(value)
+        return nil if value.nil?
+
+        if value.is_a?(Hash)
+          provider = value_for(value, :provider)
+          model = value_for(value, :model)
+          return nil if provider.to_s.empty? && model.to_s.empty?
+
+          return { provider: provider&.to_s, model: model&.to_s }
+        end
+
+        { provider: value.to_s, model: nil }
+      end
+
+      def value_for(hash, key)
+        return nil unless hash.respond_to?(:key?)
+
+        string_key = key.to_s
+        return hash[key] if hash.key?(key)
+        return hash[string_key] if hash.key?(string_key)
+
+        nil
+      end
+
+      private_class_method :merge_tick_data!, :apply_tool_hints!, :apply_suppress!, :merge_observer_data!,
+                           :normalize_routing_hint, :value_for
     end
   end
 end

--- a/lib/legion/gaia/audit_observer.rb
+++ b/lib/legion/gaia/audit_observer.rb
@@ -12,7 +12,6 @@ module Legion
       def initialize
         @user_prefs = {}
         @tool_patterns = {}
-        @quality_log  = []
         @mutex        = Mutex.new
       end
 
@@ -22,7 +21,6 @@ module Legion
         @mutex.synchronize do
           record_routing_preference(event)
           record_tool_patterns(event)
-          record_quality(event)
         end
         identity = extract_caller_identity(event)
         log.debug(
@@ -46,8 +44,7 @@ module Legion
           prefs = @user_prefs[identity] || {}
           {
             routing_preference: prefs[:routing],
-            tool_predictions: top_tools_for_patterns,
-            quality_signals: recent_quality
+            tool_predictions: top_tools_for_patterns
           }
         end
       end
@@ -56,7 +53,6 @@ module Legion
         @mutex.synchronize do
           @user_prefs.clear
           @tool_patterns.clear
-          @quality_log.clear
         end
       end
 
@@ -95,21 +91,8 @@ module Legion
         end
       end
 
-      def record_quality(event)
-        @quality_log << {
-          provider: event.dig(:routing, :provider),
-          tokens: event[:tokens],
-          timestamp: event[:timestamp]
-        }
-        @quality_log.shift if @quality_log.length > 100
-      end
-
       def top_tools_for_patterns
         @tool_patterns.sort_by { |_, v| -v[:count] }.first(10).to_h
-      end
-
-      def recent_quality
-        @quality_log.last(10)
       end
     end
   end

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -12,7 +12,8 @@ module Legion
 
       module_function
 
-      def register(identity, bond: nil, role: nil, priority: :normal, channel_identity: nil)
+      def register(identity, bond: nil, role: nil, priority: :normal, channel_identity: nil,
+                   preferred_channel: nil, last_channel: nil)
         effective_bond = (bond || role || :unknown).to_sym
         @bonds[identity.to_s] = {
           identity: identity.to_s,
@@ -20,7 +21,9 @@ module Legion
           role: effective_bond,
           priority: priority.to_sym,
           since: Time.now.utc,
-          channel_identity: channel_identity&.to_s
+          channel_identity: channel_identity&.to_s,
+          preferred_channel: preferred_channel&.to_sym,
+          last_channel: last_channel&.to_sym
         }
         log.info("BondRegistry registered identity=#{identity} bond=#{effective_bond} priority=#{priority}")
       end
@@ -53,6 +56,17 @@ module Legion
         @bonds.values
       end
 
+      def record_channel(identity, channel_id:, channel_identity: nil)
+        entry = @bonds[identity.to_s]
+        return nil unless entry
+
+        channel = channel_id&.to_sym
+        entry[:last_channel] = channel if channel
+        entry[:preferred_channel] ||= channel if channel
+        entry[:channel_identity] ||= channel_identity.to_s if channel_identity
+        entry
+      end
+
       # Returns the single best partner bond entry using deterministic selection:
       #   1. Prefer entries that have an explicit channel_identity stored (§9.6 guarantee)
       #   2. Then prefer entries with priority: :primary
@@ -81,8 +95,14 @@ module Legion
 
           identities = extract_identity_keys(content)
           priority = content.match?(/primary/i) ? :primary : :normal
+          channel_identity = extract_channel_identity(content)
+          preferred_channel = extract_channel(content, 'preferred')
+          last_channel = extract_channel(content, 'last')
 
-          identities.each { |id| register(id, bond: :partner, priority: priority) }
+          identities.each do |id|
+            register(id, bond: :partner, priority: priority, channel_identity: channel_identity,
+                         preferred_channel: preferred_channel, last_channel: last_channel)
+          end
         end
         log.info("BondRegistry hydrated entries=#{result[:results].size}")
       rescue StandardError => e
@@ -100,7 +120,24 @@ module Legion
 
         match[1].split(/[,\s]+/).map(&:strip).reject(&:empty?)
       end
-      private_class_method :extract_identity_keys
+
+      def extract_channel_identity(content)
+        match = content.match(/channel[_\s-]*identity[:\s]+([^\n]+)/i)
+        first_match_value(match)
+      end
+
+      def extract_channel(content, kind)
+        match = content.match(/#{kind}[_\s-]*channel[:\s]+([^\n]+)/i)
+        first_match_value(match)
+      end
+
+      def first_match_value(match)
+        return nil unless match
+
+        match[1].split(/[,\s]+/).first&.strip
+      end
+
+      private_class_method :extract_identity_keys, :extract_channel_identity, :extract_channel, :first_match_value
     end
   end
 end

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -9,23 +9,37 @@ module Legion
       extend Legion::Logging::Helper
 
       @bonds = Concurrent::Hash.new
+      @mutex = Mutex.new
 
       module_function
 
       def register(identity, bond: nil, role: nil, priority: :normal, channel_identity: nil,
                    preferred_channel: nil, last_channel: nil)
         effective_bond = (bond || role || :unknown).to_sym
-        @bonds[identity.to_s] = {
+        @mutex.synchronize do
+          @bonds[identity.to_s] = build_entry(
+            identity,
+            bond: effective_bond,
+            priority: priority,
+            channel_identity: channel_identity,
+            preferred_channel: preferred_channel,
+            last_channel: last_channel
+          )
+        end
+        log.info("BondRegistry registered identity=#{identity} bond=#{effective_bond} priority=#{priority}")
+      end
+
+      def build_entry(identity, bond:, priority:, channel_identity:, preferred_channel:, last_channel:)
+        {
           identity: identity.to_s,
-          bond: effective_bond,
-          role: effective_bond,
+          bond: bond,
+          role: bond,
           priority: priority.to_sym,
           since: Time.now.utc,
           channel_identity: channel_identity&.to_s,
           preferred_channel: preferred_channel&.to_sym,
           last_channel: last_channel&.to_sym
         }
-        log.info("BondRegistry registered identity=#{identity} bond=#{effective_bond} priority=#{priority}")
       end
 
       def bond(identity)
@@ -57,14 +71,18 @@ module Legion
       end
 
       def record_channel(identity, channel_id:, channel_identity: nil)
-        entry = @bonds[identity.to_s]
-        return nil unless entry
+        @mutex.synchronize do
+          entry = @bonds[identity.to_s]
+          return nil unless entry
 
-        channel = channel_id&.to_sym
-        entry[:last_channel] = channel if channel
-        entry[:preferred_channel] ||= channel if channel
-        entry[:channel_identity] ||= channel_identity.to_s if channel_identity
-        entry
+          channel = channel_id&.to_sym
+          updated = entry.merge(
+            last_channel: channel || entry[:last_channel],
+            preferred_channel: entry[:preferred_channel] || channel,
+            channel_identity: entry[:channel_identity] || channel_identity&.to_s
+          )
+          @bonds[identity.to_s] = updated
+        end
       end
 
       # Returns the single best partner bond entry using deterministic selection:
@@ -110,7 +128,7 @@ module Legion
       end
 
       def reset!
-        @bonds = Concurrent::Hash.new
+        @mutex.synchronize { @bonds = Concurrent::Hash.new }
         log.debug('BondRegistry reset')
       end
 
@@ -137,7 +155,8 @@ module Legion
         match[1].split(/[,\s]+/).first&.strip
       end
 
-      private_class_method :extract_identity_keys, :extract_channel_identity, :extract_channel, :first_match_value
+      private_class_method :build_entry, :extract_identity_keys, :extract_channel_identity, :extract_channel,
+                           :first_match_value
     end
   end
 end

--- a/lib/legion/gaia/channel_adapter.rb
+++ b/lib/legion/gaia/channel_adapter.rb
@@ -63,7 +63,7 @@ module Legion
       protected
 
       def build_intent_metadata(content)
-        require_relative 'intent_classifier' unless defined?(IntentClassifier)
+        require_relative 'intent_classifier' unless defined?(Legion::Gaia::IntentClassifier)
         classification = IntentClassifier.classify_with_engagement(content)
         {
           interaction_intent: classification[:intent],

--- a/lib/legion/gaia/channel_registry.rb
+++ b/lib/legion/gaia/channel_registry.rb
@@ -5,12 +5,14 @@ module Legion
     class ChannelRegistry
       def initialize
         @adapters = {}
+        @deliver_signature_cache = {}
         @mutex = Mutex.new
       end
 
       def register(adapter)
         @mutex.synchronize do
           @adapters[adapter.channel_id] = adapter
+          @deliver_signature_cache.delete(adapter.class)
         end
       end
 
@@ -70,14 +72,22 @@ module Legion
       end
 
       def deliver_accepts_conversation_id?(adapter)
-        parameters = adapter.class.instance_method(:deliver).parameters
-        parameters.any? do |type, name|
+        adapter_class = adapter.class
+        @mutex.synchronize do
+          return @deliver_signature_cache[adapter_class] if @deliver_signature_cache.key?(adapter_class)
+        end
+
+        accepts_conversation_id = deliver_parameters(adapter).any? do |type, name|
           %i[key keyreq].include?(type) && name == :conversation_id
         end
+        @mutex.synchronize { @deliver_signature_cache[adapter_class] = accepts_conversation_id }
+        accepts_conversation_id
+      end
+
+      def deliver_parameters(adapter)
+        adapter.class.instance_method(:deliver).parameters
       rescue StandardError
-        adapter.method(:deliver).parameters.any? do |type, name|
-          %i[key keyreq].include?(type) && name == :conversation_id
-        end
+        adapter.method(:deliver).parameters
       end
 
       def normalize_delivery_result(result, channel_id:)

--- a/lib/legion/gaia/channel_registry.rb
+++ b/lib/legion/gaia/channel_registry.rb
@@ -46,7 +46,8 @@ module Legion
         end
 
         rendered = adapter.translate_outbound(output_frame)
-        normalize_delivery_result(adapter.deliver(rendered), channel_id: output_frame.channel_id)
+        normalize_delivery_result(deliver_to_adapter(adapter, rendered, output_frame),
+                                  channel_id: output_frame.channel_id)
       end
 
       def start_all
@@ -58,6 +59,26 @@ module Legion
       end
 
       private
+
+      def deliver_to_adapter(adapter, rendered, output_frame)
+        conversation_id = output_frame.metadata[:conversation_id]
+        if conversation_id && deliver_accepts_conversation_id?(adapter)
+          adapter.deliver(rendered, conversation_id: conversation_id)
+        else
+          adapter.deliver(rendered)
+        end
+      end
+
+      def deliver_accepts_conversation_id?(adapter)
+        parameters = adapter.class.instance_method(:deliver).parameters
+        parameters.any? do |type, name|
+          %i[key keyreq].include?(type) && name == :conversation_id
+        end
+      rescue StandardError
+        adapter.method(:deliver).parameters.any? do |type, name|
+          %i[key keyreq].include?(type) && name == :conversation_id
+        end
+      end
 
       def normalize_delivery_result(result, channel_id:)
         return { delivered: false, reason: :adapter_returned_false, channel_id: channel_id } if result == false

--- a/lib/legion/gaia/channels/cli_adapter.rb
+++ b/lib/legion/gaia/channels/cli_adapter.rb
@@ -15,6 +15,7 @@ module Legion
         def initialize
           super(channel_id: :cli, capabilities: CAPABILITIES)
           @output_buffer = []
+          @mutex = Mutex.new
         end
 
         def translate_inbound(raw_input)
@@ -35,22 +36,24 @@ module Legion
         end
 
         def deliver(rendered_content)
-          @output_buffer << rendered_content
+          @mutex.synchronize { @output_buffer << rendered_content }
           rendered_content
         end
 
         def drain_output
-          output = @output_buffer.dup
-          @output_buffer.clear
-          output
+          @mutex.synchronize do
+            output = @output_buffer.dup
+            @output_buffer.clear
+            output
+          end
         end
 
         def last_output
-          @output_buffer.last
+          @mutex.synchronize { @output_buffer.last }
         end
 
         def output_buffer_size
-          @output_buffer.size
+          @mutex.synchronize { @output_buffer.size }
         end
       end
     end

--- a/lib/legion/gaia/channels/teams/bot_framework_auth.rb
+++ b/lib/legion/gaia/channels/teams/bot_framework_auth.rb
@@ -102,15 +102,17 @@ module Legion
           end
 
           def jwks_keys
-            now = Time.now.to_i
-            cache = @jwks_cache
-            return cache[:keys] if cache && cache[:expires_at] > now
+            jwks_mutex.synchronize do
+              now = Time.now.to_i
+              cache = @jwks_cache
+              return cache[:keys] if cache && cache[:expires_at] > now
 
-            metadata = fetch_json(OPENID_METADATA_URL)
-            jwks_uri = metadata['jwks_uri']
-            keys = fetch_json(jwks_uri).fetch('keys', [])
-            @jwks_cache = { keys: keys, expires_at: now + JWKS_CACHE_TTL }
-            keys
+              metadata = fetch_json(OPENID_METADATA_URL)
+              jwks_uri = metadata['jwks_uri']
+              keys = fetch_json(jwks_uri).fetch('keys', [])
+              @jwks_cache = { keys: keys, expires_at: now + JWKS_CACHE_TTL }
+              keys
+            end
           end
 
           def fetch_json(url)
@@ -146,11 +148,22 @@ module Legion
             issuer = payload['iss']
             valid_issuers = [BOT_FRAMEWORK_ISSUER]
             valid_issuers << EMULATOR_ISSUER if allow_emulator
-            valid_issuers.any? { |i| issuer&.start_with?(i) || issuer == i }
+            valid_issuers.any? { |valid_issuer| issuer_matches?(issuer, valid_issuer) }
           end
 
           def check_issuer(payload, _allow_emulator)
             { valid: false, error: :invalid_issuer, issuer: payload['iss'] }
+          end
+
+          def issuer_matches?(issuer, valid_issuer)
+            return false if issuer.to_s.empty?
+
+            prefix = valid_issuer.end_with?('/') ? valid_issuer : "#{valid_issuer}/"
+            issuer == valid_issuer || issuer.start_with?(prefix)
+          end
+
+          def jwks_mutex
+            @jwks_mutex ||= Mutex.new
           end
         end
       end

--- a/lib/legion/gaia/channels/teams/webhook_handler.rb
+++ b/lib/legion/gaia/channels/teams/webhook_handler.rb
@@ -91,7 +91,8 @@ module Legion
           end
 
           def error_response(type, detail)
-            { status: 401, type: type, detail: detail }
+            status = %i[missing_auth auth_failed].include?(type) ? 401 : 400
+            { status: status, type: type, detail: detail }
           end
         end
       end

--- a/lib/legion/gaia/intent_classifier.rb
+++ b/lib/legion/gaia/intent_classifier.rb
@@ -17,7 +17,7 @@ module Legion
       module_function
 
       def classify(content)
-        log.unknown "classify(#{content})"
+        log.debug "classify(#{content})"
         text = content.to_s.strip
         return :casual if text.empty?
 
@@ -31,12 +31,12 @@ module Legion
       end
 
       def direct_engage?(content)
-        log.unknown "direct_engage?(#{content})"
+        log.debug "direct_engage?(#{content})"
         content.to_s.match?(DIRECT_ADDRESS_PATTERN)
       end
 
       def classify_with_engagement(content)
-        log.unknown "classify_with_engagement(#{content})"
+        log.debug "classify_with_engagement(#{content})"
         { intent: classify(content), direct_engage: direct_engage?(content) }
       end
     end

--- a/lib/legion/gaia/notification_gate.rb
+++ b/lib/legion/gaia/notification_gate.rb
@@ -54,14 +54,22 @@ module Legion
       end
 
       def process_delayed
-        expired = @delay_queue.drain_expired
-        deliverable = expired.map { |e| e[:frame] }
+        candidates = @delay_queue.drain_expired
 
         unless @schedule_evaluator.quiet?
           flushed = @delay_queue.flush
-          deliverable.concat(flushed.map { |e| e[:frame] })
+          candidates.concat(flushed)
         end
 
+        deliverable = []
+        candidates.each do |entry|
+          frame = entry[:frame]
+          if evaluate(frame) == :deliver
+            deliverable << frame
+          else
+            @delay_queue.requeue(entry)
+          end
+        end
         deliverable
       end
 

--- a/lib/legion/gaia/notification_gate/behavioral_evaluator.rb
+++ b/lib/legion/gaia/notification_gate/behavioral_evaluator.rb
@@ -25,14 +25,14 @@ module Legion
           signals << arousal_signal if @arousal
           signals << idle_signal if @idle_seconds
 
-          return 1.0 if signals.empty?
+          return 0.0 if signals.empty?
 
           signals.sum / signals.size
         end
 
         def should_deliver?(priority: :normal)
           base = PRIORITY_BASE_THRESHOLD[priority] || PRIORITY_BASE_THRESHOLD[:normal]
-          effective_threshold = base + ((1.0 - notification_score) * THRESHOLD_MODIFIER)
+          effective_threshold = base + (notification_score * THRESHOLD_MODIFIER)
           priority_value(priority) >= effective_threshold
         end
 

--- a/lib/legion/gaia/notification_gate/delay_queue.rb
+++ b/lib/legion/gaia/notification_gate/delay_queue.rb
@@ -26,7 +26,7 @@ module Legion
           @mutex.synchronize do
             evicted = nil
             evicted = @entries.shift if @entries.size >= @max_size
-            @entries << entry.merge(queued_at: Time.now.utc, retry_count: entry[:retry_count].to_i + 1)
+            @entries << entry.merge(retry_count: entry[:retry_count].to_i + 1)
             evicted
           end
         end

--- a/lib/legion/gaia/notification_gate/delay_queue.rb
+++ b/lib/legion/gaia/notification_gate/delay_queue.rb
@@ -22,6 +22,15 @@ module Legion
           end
         end
 
+        def requeue(entry)
+          @mutex.synchronize do
+            evicted = nil
+            evicted = @entries.shift if @entries.size >= @max_size
+            @entries << entry.merge(queued_at: Time.now.utc, retry_count: entry[:retry_count].to_i + 1)
+            evicted
+          end
+        end
+
         def size
           @mutex.synchronize { @entries.size }
         end

--- a/lib/legion/gaia/notification_gate/schedule_evaluator.rb
+++ b/lib/legion/gaia/notification_gate/schedule_evaluator.rb
@@ -39,6 +39,10 @@ module Legion
           Australia/Sydney Australia/Melbourne Pacific/Auckland
         ].freeze
 
+        SOUTHERN_DST_ZONES = %w[
+          Australia/Sydney Australia/Melbourne Pacific/Auckland
+        ].freeze
+
         def initialize(schedule: [])
           @schedule = normalize_schedule(schedule)
         end
@@ -88,22 +92,22 @@ module Legion
         def localize(time, timezone)
           return time unless timezone
 
-          offset = tz_offset(timezone)
+          offset = tz_offset(timezone, time)
           offset ? time.getlocal(offset) : time
         end
 
-        def tz_offset(timezone)
+        def tz_offset(timezone, time = Time.now)
           return nil unless timezone
-          return tzinfo_offset(timezone) if defined?(TZInfo)
+          return tzinfo_offset(timezone, time) if defined?(TZInfo)
 
           base = STANDARD_OFFSETS[timezone]
           return nil unless base
 
-          dst_active? && DST_ZONES.include?(timezone) ? dst_shift(base) : base
+          dst_active?(timezone, time) && DST_ZONES.include?(timezone) ? dst_shift(base) : base
         end
 
-        def tzinfo_offset(timezone)
-          hours = TZInfo::Timezone.get(timezone).current_period.utc_total_offset / 3600.0
+        def tzinfo_offset(timezone, time)
+          hours = TZInfo::Timezone.get(timezone).period_for_utc(time.utc).utc_total_offset / 3600.0
           sign = hours.negative? ? '-' : '+'
           abs_h = hours.abs.to_i
           abs_m = ((hours.abs % 1) * 60).round
@@ -124,9 +128,11 @@ module Legion
           format('%<sign>s%<h>02d:%<m>02d', sign: new_sign, h: abs_total / 60, m: abs_total % 60)
         end
 
-        def dst_active?
-          m = Time.now.utc.month
-          m.between?(3, 11)
+        def dst_active?(timezone, time)
+          month = time.utc.month
+          return month >= 10 || month <= 4 if SOUTHERN_DST_ZONES.include?(timezone)
+
+          month.between?(3, 11)
         end
       end
     end

--- a/lib/legion/gaia/offline_handler.rb
+++ b/lib/legion/gaia/offline_handler.rb
@@ -21,37 +21,41 @@ module Legion
         end
 
         def agent_online?(worker_id)
-          presence = presence_store[worker_id]
+          presence = mutex.synchronize { presence_store[worker_id] }
           return false unless presence
 
           (Time.now - presence[:last_seen]) < offline_threshold
         end
 
         def record_presence(worker_id)
-          presence_store[worker_id] = { last_seen: Time.now }
+          mutex.synchronize { presence_store[worker_id] = { last_seen: Time.now } }
           log.debug("OfflineHandler recorded presence worker_id=#{worker_id}")
         end
 
         def pending_count(worker_id)
-          pending_store[worker_id]&.size || 0
+          mutex.synchronize { pending_store[worker_id]&.size || 0 }
         end
 
         def drain_pending(worker_id)
-          drained = pending_store.delete(worker_id) || []
+          drained = mutex.synchronize { pending_store.delete(worker_id) || [] }
           log.info("OfflineHandler drained pending worker_id=#{worker_id} count=#{drained.size}") if drained.any?
           drained
         end
 
         def reset!
-          @presence_store = {}
-          @pending_store = {}
+          mutex.synchronize do
+            @presence_store = {}
+            @pending_store = {}
+          end
         end
 
         private
 
         def queue_message(frame, worker_id)
-          pending_store[worker_id] ||= []
-          pending_store[worker_id] << { frame: frame, queued_at: Time.now }
+          mutex.synchronize do
+            pending_store[worker_id] ||= []
+            pending_store[worker_id] << { frame: frame, queued_at: Time.now }
+          end
         end
 
         def notify_sender(frame)
@@ -91,6 +95,10 @@ module Legion
 
         def pending_store
           @pending_store ||= {}
+        end
+
+        def mutex
+          @mutex ||= Mutex.new
         end
       end
     end

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -201,18 +201,21 @@ module Legion
       }.freeze
 
       @previous_reflection = {}
+      @previous_reflection_mutex = Mutex.new
 
       module_function
 
       def previous_reflection
-        @previous_reflection || {}
+        @previous_reflection_mutex.synchronize { @previous_reflection || {} }
       end
 
       def capture_tick_results(results)
         return unless results.is_a?(Hash)
 
         refl = results[:post_tick_reflection]
-        @previous_reflection = refl if refl.is_a?(Hash) && refl[:status] != :skipped
+        @previous_reflection_mutex.synchronize do
+          @previous_reflection = refl if refl.is_a?(Hash) && refl[:status] != :skipped
+        end
       end
 
       def build_cognitive_state(prior_results)

--- a/lib/legion/gaia/proactive_dispatcher.rb
+++ b/lib/legion/gaia/proactive_dispatcher.rb
@@ -23,43 +23,57 @@ module Legion
         @dispatch_log    = []
         @pending_buffer  = []
         @last_ignored_at = nil
+        @mutex           = Mutex.new
       end
 
       def can_dispatch?
-        prune_old_dispatches!
-        return false if @dispatch_log.size >= @max_per_day
-        return false if @dispatch_log.any? && (Time.now.utc - @dispatch_log.last[:at]) < @min_interval
-        return false if @last_ignored_at && (Time.now.utc - @last_ignored_at) < @ignore_cooldown
+        @mutex.synchronize do
+          prune_old_dispatches!
+          return false if @dispatch_log.size >= @max_per_day
+          return false if @dispatch_log.any? && (Time.now.utc - @dispatch_log.last[:at]) < @min_interval
+          return false if @last_ignored_at && (Time.now.utc - @last_ignored_at) < @ignore_cooldown
+        end
 
         true
       end
 
       def record_dispatch!
-        prune_old_dispatches!
-        @dispatch_log << { at: Time.now.utc }
-        log.info("ProactiveDispatcher recorded dispatch count=#{@dispatch_log.size}")
+        count = @mutex.synchronize do
+          prune_old_dispatches!
+          @dispatch_log << { at: Time.now.utc }
+          @dispatch_log.size
+        end
+        log.info("ProactiveDispatcher recorded dispatch count=#{count}")
       end
 
       def record_ignored!
-        @last_ignored_at = Time.now.utc
+        @mutex.synchronize { @last_ignored_at = Time.now.utc }
         log.info('ProactiveDispatcher recorded ignored interaction')
       end
 
       def dispatches_today
-        prune_old_dispatches!
-        @dispatch_log.size
+        @mutex.synchronize do
+          prune_old_dispatches!
+          @dispatch_log.size
+        end
       end
 
       def queue_intent(intent)
-        @pending_buffer << intent
-        @pending_buffer.shift while @pending_buffer.size > MAX_PENDING
+        pending = @mutex.synchronize do
+          @pending_buffer << intent
+          @pending_buffer.shift while @pending_buffer.size > MAX_PENDING
+          @pending_buffer.size
+        end
         log.info("ProactiveDispatcher queued intent reason=#{intent.dig(:trigger,
-                                                                        :reason)} pending=#{@pending_buffer.size}")
+                                                                        :reason)} pending=#{pending}")
       end
 
       def drain_pending
-        drained = @pending_buffer.dup
-        @pending_buffer.clear
+        drained = @mutex.synchronize do
+          copy = @pending_buffer.dup
+          @pending_buffer.clear
+          copy
+        end
         log.info("ProactiveDispatcher drained pending count=#{drained.size}") if drained.any?
         drained
       end

--- a/lib/legion/gaia/router/router_bridge.rb
+++ b/lib/legion/gaia/router/router_bridge.rb
@@ -11,8 +11,8 @@ module Legion
         attr_reader :worker_routing, :channel_registry, :started
 
         def initialize(channel_registry:, worker_routing: nil, allowed_worker_ids: [])
-          log.unknown "initialize(channel_registry: #{channel_registry}, " \
-                      "worker_routing: #{worker_routing}, allowed_worker_ids: #{allowed_worker_ids}"
+          log.debug "initialize(channel_registry: #{channel_registry}, " \
+                    "worker_routing: #{worker_routing}, allowed_worker_ids: #{allowed_worker_ids}"
           @channel_registry = channel_registry
           @worker_routing = worker_routing || WorkerRouting.new(allowed_worker_ids: allowed_worker_ids)
           @started = false
@@ -20,10 +20,12 @@ module Legion
 
         def start
           @started = true
+          subscribe_outbound if transport_available?
           log.info("RouterBridge started workers=#{@worker_routing.size}")
         end
 
         def stop
+          @outbound_consumer&.cancel if @outbound_consumer.respond_to?(:cancel)
           @started = false
           log.info('RouterBridge stopped')
         end
@@ -33,7 +35,7 @@ module Legion
         end
 
         def route_inbound(input_frame)
-          log.unknown "route_inbound(input_frame: #{input_frame})"
+          log.debug "route_inbound(input_frame: #{input_frame})"
           return { routed: false, reason: :not_started } unless started?
 
           identity = extract_identity(input_frame)
@@ -47,7 +49,7 @@ module Legion
         end
 
         def route_outbound(payload)
-          log.unknown "route_outbound(payload: #{payload})"
+          log.debug "route_outbound(payload: #{payload})"
           return { delivered: false, reason: :not_started } unless started?
 
           frame = reconstruct_output_frame(payload)
@@ -82,6 +84,18 @@ module Legion
 
         private
 
+        def subscribe_outbound
+          queue = Transport::Queues::Outbound.new
+          @outbound_consumer = queue.subscribe(manual_ack: true, block: false) do |delivery_info, _metadata, payload|
+            message = decode_payload(payload)
+            route_outbound(message) if message
+            queue.acknowledge(delivery_info.delivery_tag)
+          rescue StandardError => e
+            handle_exception(e, level: :error, operation: 'gaia.router.router_bridge.subscribe_outbound')
+            queue.reject(delivery_info.delivery_tag)
+          end
+        end
+
         def extract_identity(input_frame)
           input_frame.auth_context[:principal_id] ||
             input_frame.auth_context[:aad_object_id] ||
@@ -108,13 +122,23 @@ module Legion
 
         def offline_response(input_frame)
           identity = extract_identity(input_frame)
+          offline_result = OfflineHandler.handle_offline_delivery(input_frame, worker_id: identity || :unassigned)
           log.warn("RouterBridge could not route inbound frame_id=#{input_frame.id} identity=#{identity}")
           {
             routed: false,
             reason: :worker_not_found,
             identity: identity,
-            frame_id: input_frame.id
+            frame_id: input_frame.id,
+            queued: offline_result[:queued]
           }
+        end
+
+        def decode_payload(raw)
+          parsed = Legion::JSON.load(raw)
+          parsed.is_a?(Hash) ? parsed : nil
+        rescue StandardError => e
+          handle_exception(e, level: :warn, operation: 'gaia.router.router_bridge.decode_payload')
+          nil
         end
 
         def reconstruct_output_frame(payload)

--- a/lib/legion/gaia/router/router_bridge.rb
+++ b/lib/legion/gaia/router/router_bridge.rb
@@ -88,11 +88,24 @@ module Legion
           queue = Transport::Queues::Outbound.new
           @outbound_consumer = queue.subscribe(manual_ack: true, block: false) do |delivery_info, _metadata, payload|
             message = decode_payload(payload)
-            route_outbound(message) if message
-            queue.acknowledge(delivery_info.delivery_tag)
+            unless message
+              queue.reject(delivery_info.delivery_tag, requeue: false)
+              next
+            end
+
+            delivery_result = route_outbound(message)
+            if delivery_result.is_a?(Hash) && delivery_result[:delivered] == true && !delivery_result[:error]
+              queue.acknowledge(delivery_info.delivery_tag)
+            else
+              log.warn(
+                'RouterBridge outbound delivery not acknowledged ' \
+                "reason=#{delivery_result[:reason] || delivery_result[:error] || :unknown}"
+              )
+              queue.reject(delivery_info.delivery_tag, requeue: true)
+            end
           rescue StandardError => e
             handle_exception(e, level: :error, operation: 'gaia.router.router_bridge.subscribe_outbound')
-            queue.reject(delivery_info.delivery_tag)
+            queue.reject(delivery_info.delivery_tag, requeue: false)
           end
         end
 

--- a/lib/legion/gaia/router/worker_routing.rb
+++ b/lib/legion/gaia/router/worker_routing.rb
@@ -9,7 +9,7 @@ module Legion
         attr_reader :allowed_worker_ids
 
         def initialize(allowed_worker_ids: [])
-          log.unknown "initialize(allowed_worker_ids: #{allowed_worker_ids})"
+          log.debug "initialize(allowed_worker_ids: #{allowed_worker_ids})"
           @routes = {}
           @allowed_worker_ids = allowed_worker_ids
           @mutex = Mutex.new

--- a/lib/legion/gaia/routes.rb
+++ b/lib/legion/gaia/routes.rb
@@ -10,7 +10,7 @@
 module Legion
   module Gaia
     module Routes
-      def self.registered(app)
+      def self.registered(app) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         app.helpers do # rubocop:disable Metrics/BlockLength
           unless method_defined?(:gaia_available?)
             define_method(:gaia_available?) do
@@ -47,9 +47,9 @@ module Legion
           end
 
           unless method_defined?(:json_error)
-            define_method(:json_error) do |code, message, status_code: 400|
+            define_method(:json_error) do |code, message, status_code: nil|
               content_type :json
-              status status_code
+              status status_code if status_code
               Legion::JSON.dump({ error: { code: code, message: message } })
             end
           end
@@ -76,7 +76,7 @@ module Legion
 
       def self.register_ticks_route(app)
         app.get '/api/gaia/ticks' do
-          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+          halt 503, json_error('gaia_unavailable', 'gaia is not started') unless gaia_available?
 
           max_limit =
             if defined?(Legion::Gaia::TickHistory) && Legion::Gaia::TickHistory.const_defined?(:MAX_ENTRIES)
@@ -93,7 +93,7 @@ module Legion
 
       def self.register_channels_route(app)
         app.get '/api/gaia/channels' do
-          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+          halt 503, json_error('gaia_unavailable', 'gaia is not started') unless gaia_available?
 
           registry = Legion::Gaia.channel_registry
           return json_response({ channels: [] }) unless registry
@@ -109,7 +109,7 @@ module Legion
 
       def self.register_buffer_route(app)
         app.get '/api/gaia/buffer' do
-          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+          halt 503, json_error('gaia_unavailable', 'gaia is not started') unless gaia_available?
 
           buffer = Legion::Gaia.sensory_buffer
           json_response({
@@ -122,7 +122,7 @@ module Legion
 
       def self.register_sessions_route(app)
         app.get '/api/gaia/sessions' do
-          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+          halt 503, json_error('gaia_unavailable', 'gaia is not started') unless gaia_available?
 
           store = Legion::Gaia.session_store
           json_response({
@@ -176,14 +176,14 @@ module Legion
 
       def self.register_ingest_route(app)
         app.post '/api/gaia/ingest' do
-          halt 503, json_error('gaia_unavailable', 'gaia is not started', status_code: 503) unless gaia_available?
+          halt 503, json_error('gaia_unavailable', 'gaia is not started') unless gaia_available?
 
           body = Legion::JSON.load(request.body.read)
           content  = body[:content] || body['content']
           identity = body[:identity] || body['identity'] || 'unknown'
           channel  = (body[:channel_id] || body['channel_id'] || 'cli').to_sym
 
-          halt 400, json_error('missing_content', 'content is required', status_code: 400) if content.to_s.empty?
+          halt 400, json_error('missing_content', 'content is required') if content.to_s.empty?
 
           frame = Legion::Gaia::InputFrame.new(
             content: content,

--- a/lib/legion/gaia/session_store.rb
+++ b/lib/legion/gaia/session_store.rb
@@ -110,7 +110,7 @@ module Legion
         # during the migration window.
         @identity_index[normalized_identity] = old_session_id
         @canonical_to_uuid[canonical_key] = normalized_identity
-        (@session_identity_index[old_session_id] ||= []) << normalized_identity
+        (@session_identity_index[old_session_id] ||= []).push(canonical_key, normalized_identity).uniq!
         old_session_id
       end
 

--- a/lib/legion/gaia/tick_history.rb
+++ b/lib/legion/gaia/tick_history.rb
@@ -17,12 +17,12 @@ module Legion
       def record(tick_result)
         return unless tick_result.is_a?(Hash) && tick_result[:results].is_a?(Hash)
 
-        timestamp = Time.now.utc.iso8601
+        timestamp = Time.now.utc.iso8601(3).freeze
         new_events = tick_result[:results].filter_map do |phase_name, phase_data|
           next unless phase_data.is_a?(Hash)
 
           {
-            timestamp: timestamp.freeze,
+            timestamp: timestamp,
             phase: phase_name.to_s.freeze,
             duration_ms: phase_data[:elapsed_ms] || phase_data[:duration_ms] || 0.0,
             status: phase_data[:status] || :completed

--- a/lib/legion/gaia/tracker_persistence.rb
+++ b/lib/legion/gaia/tracker_persistence.rb
@@ -12,13 +12,15 @@ module Legion
       module_function
 
       def register_tracker(name, tracker:, tags:)
-        @trackers ||= {}
-        @trackers[name] = { tracker: tracker, tags: tags }
+        mutex.synchronize do
+          @trackers ||= {}
+          @trackers[name] = { tracker: tracker, tags: tags }
+        end
         log.info("TrackerPersistence registered tracker=#{name} tags=#{Array(tags).join(',')}")
       end
 
       def registered_trackers
-        @trackers || {}
+        mutex.synchronize { (@trackers || {}).dup }
       end
 
       def flush_dirty(store: nil)
@@ -26,7 +28,8 @@ module Legion
 
         failed = false
         flushed = 0
-        registered_trackers.each_value do |entry|
+        entries = registered_trackers.values
+        entries.each do |entry|
           tracker = entry[:tracker]
           next unless tracker.dirty?
 
@@ -36,7 +39,7 @@ module Legion
             failed = true
           end
         end
-        @last_flush_at = Time.now.utc unless failed
+        mutex.synchronize { @last_flush_at = Time.now.utc } unless failed
         if failed
           log.warn("TrackerPersistence flush_dirty completed with errors flushed=#{flushed}")
         else
@@ -50,11 +53,12 @@ module Legion
         return unless store
 
         failed = false
-        registered_trackers.each_value do |entry|
+        entries = registered_trackers.values
+        entries.each do |entry|
           failed ||= !flush_tracker(entry[:tracker], store: store)
         end
-        @last_flush_at = Time.now.utc unless failed
-        log.info("TrackerPersistence flushed all trackers count=#{registered_trackers.size}")
+        mutex.synchronize { @last_flush_at = Time.now.utc } unless failed
+        log.info("TrackerPersistence flushed all trackers count=#{entries.size}")
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.tracker_persistence.flush_all')
       end
@@ -71,18 +75,22 @@ module Legion
       end
 
       def last_flush_at
-        @last_flush_at
+        mutex.synchronize { @last_flush_at }
       end
 
       def should_flush?
-        return true if @last_flush_at.nil?
+        mutex.synchronize do
+          return true if @last_flush_at.nil?
 
-        (Time.now.utc - @last_flush_at) >= FLUSH_INTERVAL
+          (Time.now.utc - @last_flush_at) >= FLUSH_INTERVAL
+        end
       end
 
       def reset!
-        @trackers = {}
-        @last_flush_at = nil
+        mutex.synchronize do
+          @trackers = {}
+          @last_flush_at = nil
+        end
       end
 
       def flush_tracker(tracker, store:)
@@ -118,6 +126,11 @@ module Legion
         true
       end
       private_class_method :upsert_succeeded?
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+      private_class_method :mutex
     end
   end
 end

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.51'
+    VERSION = '0.9.52'
   end
 end

--- a/lib/legion/gaia/workflow/instance.rb
+++ b/lib/legion/gaia/workflow/instance.rb
@@ -51,16 +51,18 @@ module Legion
           self
         end
 
-        # Non-raising variant — returns true on success, false on guard/checkpoint failure.
-        # Unknown-state and invalid-transition errors still propagate.
+        # Non-raising variant — returns true on success, false on transition failure.
+        # Pass strict: true to propagate unknown-state and invalid-transition errors.
         #
         # @param to_state [Symbol]
         # @param ctx [Hash]
         # @return [Boolean]
-        def transition(to_state, **ctx)
+        def transition(to_state, strict: false, **ctx)
           transition!(to_state, **ctx)
           true
-        rescue GuardRejected, CheckpointBlocked => e
+        rescue GuardRejected, CheckpointBlocked, UnknownState, InvalidTransition => e
+          raise if strict && (e.is_a?(UnknownState) || e.is_a?(InvalidTransition))
+
           handle_exception(e, level: :debug, operation: 'gaia.workflow.instance.transition',
                               workflow: definition.name, to_state: to_state)
           false

--- a/spec/legion/gaia/advisory_spec.rb
+++ b/spec/legion/gaia/advisory_spec.rb
@@ -52,10 +52,44 @@ RSpec.describe Legion::Gaia::Advisory do
       expect(result[:tool_hint]).to be_nil
     end
 
-    it 'never raises, returns nil on error' do
+    it 'never raises, returns empty hash on error' do
       allow(Legion::Gaia).to receive(:started?).and_raise(StandardError, 'boom')
       result = described_class.advise(conversation_id: 'c', messages: [], caller: {})
-      expect(result).to be_nil
+      expect(result).to eq({})
+    end
+
+    it 'handles string-keyed tool predictions' do
+      allow(Legion::Gaia).to receive(:started?).and_return(true)
+      allow(Legion::Gaia).to receive(:last_valences).and_return(nil)
+      allow(Legion::Gaia).to receive(:registry).and_return(
+        double(tick_host: double(
+          last_tick_result: {
+            results: {
+              prediction_engine: { predictions: [{ 'tool' => 'read_file', 'confidence' => 0.9 }] }
+            }
+          }
+        ))
+      )
+
+      result = described_class.advise(conversation_id: 'c', messages: [], caller: {})
+      expect(result[:tool_hint]).to eq(['read_file'])
+    end
+
+    it 'normalizes routing hints to provider and model keys' do
+      allow(Legion::Gaia).to receive(:started?).and_return(true)
+      allow(Legion::Gaia).to receive(:last_valences).and_return(nil)
+      allow(Legion::Gaia).to receive(:registry).and_return(
+        double(tick_host: double(
+          last_tick_result: {
+            results: {
+              post_tick_reflection: { routing_preference: { 'provider' => :anthropic, model: :sonnet } }
+            }
+          }
+        ))
+      )
+
+      result = described_class.advise(conversation_id: 'c', messages: [], caller: {})
+      expect(result[:routing_hint]).to eq(provider: 'anthropic', model: 'sonnet')
     end
 
     describe 'with observer data' do
@@ -79,7 +113,7 @@ RSpec.describe Legion::Gaia::Advisory do
           caller: { requested_by: { identity: 'user:matt', type: :user } }
         )
 
-        expect(result[:routing_hint]).to include(provider: :claude)
+        expect(result[:routing_hint]).to include(provider: 'claude')
       end
 
       it 'includes learned tool predictions from observer' do

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe Legion::Gaia::BondRegistry do
         expect(described_class.bond('esity')).to eq(:unknown)
       end
     end
+
+    it 'stores preferred and last channel metadata' do
+      described_class.register('esity', bond: :partner, preferred_channel: :teams, last_channel: :slack)
+      entry = described_class.all_bonds.find { |b| b[:identity] == 'esity' }
+      expect(entry[:preferred_channel]).to eq(:teams)
+      expect(entry[:last_channel]).to eq(:slack)
+    end
   end
 
   describe '.bond' do
@@ -125,6 +132,23 @@ RSpec.describe Legion::Gaia::BondRegistry do
       expect(described_class.partner?('miverso2')).to be true
     end
 
+    it 'restores channel identity and channel metadata from Apollo Local seed data' do
+      stub_apollo = double('Apollo::Local')
+      seed_content = "Identity keys: partner-uuid\nBond type: partner\n" \
+                     "Channel identity: U_TEAMS_1\nPreferred channel: teams\nLast channel: slack"
+      allow(stub_apollo).to receive(:query).and_return(
+        success: true,
+        results: [{ content: seed_content, tags: %w[partner bond self-knowledge] }]
+      )
+
+      described_class.hydrate_from_apollo(store: stub_apollo)
+      entry = described_class.partner_entry
+
+      expect(entry[:channel_identity]).to eq('U_TEAMS_1')
+      expect(entry[:preferred_channel]).to eq(:teams)
+      expect(entry[:last_channel]).to eq(:slack)
+    end
+
     it 'handles missing Apollo gracefully' do
       expect { described_class.hydrate_from_apollo(store: nil) }.not_to raise_error
       expect(described_class.all_bonds).to be_empty
@@ -201,6 +225,18 @@ RSpec.describe Legion::Gaia::BondRegistry do
       described_class.register('esity', bond: :partner)
       entry = described_class.all_bonds.find { |b| b[:identity] == 'esity' }
       expect(entry[:channel_identity]).to be_nil
+    end
+  end
+
+  describe '.record_channel' do
+    it 'updates the last seen channel for an existing bond' do
+      described_class.register('aad-1', bond: :partner)
+      described_class.record_channel('aad-1', channel_id: :teams, channel_identity: 'teams-user-1')
+      entry = described_class.partner_entry
+
+      expect(entry[:last_channel]).to eq(:teams)
+      expect(entry[:preferred_channel]).to eq(:teams)
+      expect(entry[:channel_identity]).to eq('teams-user-1')
     end
   end
 end

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -238,5 +238,16 @@ RSpec.describe Legion::Gaia::BondRegistry do
       expect(entry[:preferred_channel]).to eq(:teams)
       expect(entry[:channel_identity]).to eq('teams-user-1')
     end
+
+    it 'stores an updated entry instead of mutating the previous hash in place' do
+      described_class.register('aad-1', bond: :partner)
+      original_entry = described_class.all_bonds.find { |entry| entry[:identity] == 'aad-1' }
+
+      updated_entry = described_class.record_channel('aad-1', channel_id: :teams)
+
+      expect(updated_entry).not_to equal(original_entry)
+      expect(original_entry[:last_channel]).to be_nil
+      expect(updated_entry[:last_channel]).to eq(:teams)
+    end
   end
 end

--- a/spec/legion/gaia/channel_registry_spec.rb
+++ b/spec/legion/gaia/channel_registry_spec.rb
@@ -106,6 +106,30 @@ RSpec.describe Legion::Gaia::ChannelRegistry do
       result = registry.deliver(frame)
       expect(result[:delivered]).to be true
     end
+
+    it 'caches conversation_id signature detection per adapter class' do
+      adapter_class = Class.new do
+        def channel_id = :cached
+        def started? = true
+        def translate_outbound(frame) = frame.content
+
+        def deliver(rendered,
+                    conversation_id: nil)
+          { delivered: true, rendered: rendered, conversation_id: conversation_id }
+        end
+      end
+      adapter = adapter_class.new
+      frame = Legion::Gaia::OutputFrame.new(
+        content: 'hello',
+        channel_id: :cached,
+        metadata: { conversation_id: 'conv-1' }
+      )
+
+      registry.register(adapter)
+      expect(adapter_class).to receive(:instance_method).with(:deliver).once.and_call_original
+
+      2.times { expect(registry.deliver(frame)[:delivered]).to be true }
+    end
   end
 
   describe '#start_all / #stop_all' do

--- a/spec/legion/gaia/channel_registry_spec.rb
+++ b/spec/legion/gaia/channel_registry_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe Legion::Gaia::ChannelRegistry do
       expect(result[:error]).to eq(:network_error)
       expect(result[:channel_id]).to eq(:cli)
     end
+
+    it 'passes conversation_id to adapters that accept it' do
+      teams_adapter = Legion::Gaia::Channels::TeamsAdapter.new
+      teams_adapter.start
+      frame = Legion::Gaia::OutputFrame.new(
+        content: 'hello',
+        channel_id: :teams,
+        metadata: { conversation_id: 'conv-1' }
+      )
+
+      registry.register(teams_adapter)
+      allow(teams_adapter).to receive(:translate_outbound).with(frame).and_return({ type: 'text', text: 'hello' })
+      allow(teams_adapter).to receive(:deliver).with({ type: 'text', text: 'hello' },
+                                                     conversation_id: 'conv-1').and_return({ delivered: true })
+
+      result = registry.deliver(frame)
+      expect(result[:delivered]).to be true
+    end
   end
 
   describe '#start_all / #stop_all' do

--- a/spec/legion/gaia/channels/teams/bot_framework_auth_spec.rb
+++ b/spec/legion/gaia/channels/teams/bot_framework_auth_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe Legion::Gaia::Channels::Teams::BotFrameworkAuth do
         expect(result[:error]).to eq(:invalid_issuer)
       end
 
+      it 'rejects issuer subdomain spoofing' do
+        payload = valid_payload.merge('iss' => 'https://api.botframework.com.attacker.com')
+        token = build_jwt(header, payload)
+        result = described_class.validate_token(token, app_id: app_id)
+        expect(result[:error]).to eq(:invalid_issuer)
+      end
+
       it 'rejects wrong audience' do
         payload = valid_payload.merge('aud' => 'wrong-app-id')
         token = build_jwt(header, payload)

--- a/spec/legion/gaia/channels/teams/webhook_handler_spec.rb
+++ b/spec/legion/gaia/channels/teams/webhook_handler_spec.rb
@@ -87,8 +87,17 @@ RSpec.describe Legion::Gaia::Channels::Teams::WebhookHandler do
     context 'with invalid payload' do
       it 'returns error for unparseable body' do
         result = handler.handle(request_body: 'not json at all {{{')
-        expect(result[:status]).to eq(401)
+        expect(result[:status]).to eq(400)
         expect(result[:type]).to eq(:invalid_payload)
+      end
+    end
+
+    context 'when translation fails' do
+      it 'returns bad request instead of auth failure' do
+        allow(adapter).to receive(:translate_inbound).and_return(nil)
+        result = handler.handle(request_body: message_activity)
+        expect(result[:status]).to eq(400)
+        expect(result[:type]).to eq(:translate_failed)
       end
     end
 

--- a/spec/legion/gaia/notification_gate/behavioral_evaluator_spec.rb
+++ b/spec/legion/gaia/notification_gate/behavioral_evaluator_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Legion::Gaia::NotificationGate::BehavioralEvaluator do
   subject(:evaluator) { described_class.new }
 
   describe '#notification_score' do
-    it 'returns 1.0 with no signals' do
-      expect(evaluator.notification_score).to eq(1.0)
+    it 'returns 0.0 with no signals' do
+      expect(evaluator.notification_score).to eq(0.0)
     end
 
     it 'lowers score when arousal is low' do
@@ -35,9 +35,15 @@ RSpec.describe Legion::Gaia::NotificationGate::BehavioralEvaluator do
   end
 
   describe '#should_deliver?' do
-    it 'delivers normal priority when score is high' do
+    it 'delays normal priority when arousal is high' do
       evaluator.update_arousal(1.0)
       evaluator.update_idle_seconds(0)
+      expect(evaluator.should_deliver?(priority: :normal)).to be false
+    end
+
+    it 'delivers normal priority when arousal is low and idle is high' do
+      evaluator.update_arousal(0.0)
+      evaluator.update_idle_seconds(3600)
       expect(evaluator.should_deliver?(priority: :normal)).to be true
     end
 

--- a/spec/legion/gaia/notification_gate/delay_queue_spec.rb
+++ b/spec/legion/gaia/notification_gate/delay_queue_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe Legion::Gaia::NotificationGate::DelayQueue do
     end
   end
 
+  describe '#requeue' do
+    it 'preserves the original queued_at while incrementing retry_count' do
+      queued_at = Time.now.utc - 14_401
+      queue.requeue(frame: frame, queued_at: queued_at, retry_count: 2)
+
+      entry = queue.pending.first
+      expect(entry[:queued_at]).to eq(queued_at)
+      expect(entry[:retry_count]).to eq(3)
+    end
+  end
+
   describe '#flush' do
     it 'returns all entries' do
       3.times { queue.enqueue(frame) }

--- a/spec/legion/gaia/notification_gate/schedule_evaluator_spec.rb
+++ b/spec/legion/gaia/notification_gate/schedule_evaluator_spec.rb
@@ -131,5 +131,23 @@ RSpec.describe Legion::Gaia::NotificationGate::ScheduleEvaluator do
         expect { evaluator.quiet?(at: time) }.not_to raise_error
       end
     end
+
+    context 'with Southern Hemisphere DST fallback' do
+      before { hide_const('TZInfo') if defined?(TZInfo) }
+
+      subject(:evaluator) do
+        described_class.new(schedule: [{
+                              days: %w[wed],
+                              start: '20:30',
+                              end: '21:30',
+                              timezone: 'Australia/Sydney'
+                            }])
+      end
+
+      it 'applies DST during Sydney summer months' do
+        time = Time.utc(2026, 11, 4, 10, 0, 0)
+        expect(evaluator.quiet?(at: time)).to be true
+      end
+    end
   end
 end

--- a/spec/legion/gaia/notification_gate_spec.rb
+++ b/spec/legion/gaia/notification_gate_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe Legion::Gaia::NotificationGate do
       before do
         allow(gate.schedule_evaluator).to receive(:quiet?).and_return(false)
         gate.enqueue(frame_normal)
-        gate.enqueue(frame_low)
+        gate.enqueue(frame_urgent)
       end
 
       it 'returns all pending frames' do
         result = gate.process_delayed
-        expect(result).to contain_exactly(frame_normal, frame_low)
+        expect(result).to contain_exactly(frame_normal, frame_urgent)
       end
 
       it 'drops pending_count to 0' do
@@ -100,6 +100,20 @@ RSpec.describe Legion::Gaia::NotificationGate do
 
       it 'leaves pending_count unchanged' do
         expect { gate.process_delayed }.not_to change(gate, :pending_count)
+      end
+    end
+
+    context 'when presence still blocks delivery after quiet hours end' do
+      before do
+        allow(gate.schedule_evaluator).to receive(:quiet?).and_return(false)
+        gate.update_presence(availability: 'DoNotDisturb')
+        gate.enqueue(frame_normal)
+      end
+
+      it 'requeues the frame instead of flushing it' do
+        result = gate.process_delayed
+        expect(result).to be_empty
+        expect(gate.pending_count).to eq(1)
       end
     end
   end

--- a/spec/legion/gaia/proactive_dispatcher_spec.rb
+++ b/spec/legion/gaia/proactive_dispatcher_spec.rb
@@ -235,6 +235,18 @@ RSpec.describe Legion::Gaia::ProactiveDispatcher do
         expect(dispatcher.send(:resolve_partner_channel)).to be_nil
       end
     end
+
+    context 'when BondRegistry stores a preferred channel' do
+      before do
+        Legion::Gaia::BondRegistry.reset!
+        Legion::Gaia::BondRegistry.register('esity', bond: :partner, preferred_channel: :teams)
+      end
+      after { Legion::Gaia::BondRegistry.reset! }
+
+      it 'resolves the stored preferred channel without stubbing' do
+        expect(dispatcher.send(:resolve_partner_channel)).to eq(:teams)
+      end
+    end
   end
 
   describe '#resolve_partner_id with multiple partner bonds (§9.6 deterministic selection)' do

--- a/spec/legion/gaia/router/router_bridge_spec.rb
+++ b/spec/legion/gaia/router/router_bridge_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe Legion::Gaia::Router::RouterBridge do
         result = bridge.route_inbound(input_frame)
         expect(result[:routed]).to be false
         expect(result[:reason]).to eq(:worker_not_found)
+        expect(result[:queued]).to be true
+        expect(Legion::Gaia::OfflineHandler.pending_count('oid-1')).to eq(1)
       end
 
       it 'routes to registered worker' do
@@ -114,6 +116,32 @@ RSpec.describe Legion::Gaia::Router::RouterBridge do
         expect(result[:delivered]).to be false
         expect(result[:reason]).to eq(:no_adapter)
       end
+    end
+  end
+
+  describe '#start with transport available' do
+    it 'subscribes the outbound queue and routes delivered payloads' do
+      outbound_queue = double('OutboundQueue')
+      outbound_class = double('OutboundClass', new: outbound_queue)
+      delivery_info = double('delivery_info', delivery_tag: 'tag-1')
+      payload = Legion::JSON.dump({ id: 'frame-2', content: 'hello', content_type: :text, channel_id: :cli })
+
+      stub_const('Legion::Gaia::Router::Transport', Module.new) unless defined?(Legion::Gaia::Router::Transport)
+      stub_const('Legion::Gaia::Router::Transport::Queues', Module.new)
+      stub_const('Legion::Gaia::Router::Transport::Queues::Outbound', outbound_class)
+      allow(bridge).to receive(:transport_available?).and_return(true)
+      allow(outbound_queue).to receive(:subscribe) do |manual_ack:, block:, &handler|
+        expect(manual_ack).to be true
+        expect(block).to be false
+        handler.call(delivery_info, nil, payload)
+        double('consumer', cancel: true)
+      end
+      allow(outbound_queue).to receive(:acknowledge)
+
+      bridge.start
+
+      expect(cli_adapter.last_output).to eq('hello')
+      expect(outbound_queue).to have_received(:acknowledge).with('tag-1')
     end
   end
 end

--- a/spec/legion/gaia/router/router_bridge_spec.rb
+++ b/spec/legion/gaia/router/router_bridge_spec.rb
@@ -137,11 +137,37 @@ RSpec.describe Legion::Gaia::Router::RouterBridge do
         double('consumer', cancel: true)
       end
       allow(outbound_queue).to receive(:acknowledge)
+      allow(outbound_queue).to receive(:reject)
 
       bridge.start
 
       expect(cli_adapter.last_output).to eq('hello')
       expect(outbound_queue).to have_received(:acknowledge).with('tag-1')
+    end
+
+    it 'requeues outbound payloads when delivery fails' do
+      outbound_queue = double('OutboundQueue')
+      outbound_class = double('OutboundClass', new: outbound_queue)
+      delivery_info = double('delivery_info', delivery_tag: 'tag-2')
+      payload = Legion::JSON.dump({ id: 'frame-3', content: 'hello', content_type: :text, channel_id: :missing })
+
+      stub_const('Legion::Gaia::Router::Transport', Module.new) unless defined?(Legion::Gaia::Router::Transport)
+      stub_const('Legion::Gaia::Router::Transport::Queues', Module.new)
+      stub_const('Legion::Gaia::Router::Transport::Queues::Outbound', outbound_class)
+      allow(bridge).to receive(:transport_available?).and_return(true)
+      allow(outbound_queue).to receive(:subscribe) do |manual_ack:, block:, &handler|
+        expect(manual_ack).to be true
+        expect(block).to be false
+        handler.call(delivery_info, nil, payload)
+        double('consumer', cancel: true)
+      end
+      allow(outbound_queue).to receive(:acknowledge)
+      allow(outbound_queue).to receive(:reject)
+
+      bridge.start
+
+      expect(outbound_queue).not_to have_received(:acknowledge)
+      expect(outbound_queue).to have_received(:reject).with('tag-2', requeue: true)
     end
   end
 end

--- a/spec/legion/gaia/session_store_spec.rb
+++ b/spec/legion/gaia/session_store_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe Legion::Gaia::SessionStore do
         expect(third).not_to be_nil
       end
 
+      it 'cleans the canonical key after a migrated session expires' do
+        expiring_store = described_class.new(ttl: 0)
+        string_session = expiring_store.find_or_create(identity: 'esity')
+        expiring_store.find_or_create(identity: uuid, canonical_name: 'esity')
+        sleep(0.01)
+
+        expiring_store.prune_expired
+        fresh = expiring_store.find_or_create(identity: 'esity')
+
+        expect(fresh.id).not_to eq(string_session.id)
+      end
+
       it 'creates new session if no string session exists to migrate' do
         session = store.find_or_create(identity: uuid, canonical_name: 'esity')
         expect(session.identity).to eq(uuid)

--- a/spec/legion/gaia/tick_history_spec.rb
+++ b/spec/legion/gaia/tick_history_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe Legion::Gaia::TickHistory do
       expect(entry[:duration_ms]).to eq(0.0)
     end
 
-    it 'stores an ISO8601 timestamp' do
+    it 'stores an ISO8601 timestamp with millisecond precision' do
       history.record({ results: { identity_entropy_check: { elapsed_ms: 1, status: :ok } } })
       entry = history.recent(limit: 1).first
-      expect(entry[:timestamp]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+      expect(entry[:timestamp]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
     end
 
     it 'skips phase entries whose data is not a hash' do

--- a/spec/legion/gaia/workflow/instance_spec.rb
+++ b/spec/legion/gaia/workflow/instance_spec.rb
@@ -214,13 +214,21 @@ RSpec.describe Legion::Gaia::Workflow::Instance do
       expect(instance.transition(:indexed, score: 0.1)).to be false
     end
 
-    it 'still raises InvalidTransition (programmer error)' do
-      expect { instance.transition(:indexed) }
+    it 'returns false when the transition is invalid' do
+      expect(instance.transition(:indexed)).to be false
+    end
+
+    it 'returns false when the target state is unknown' do
+      expect(instance.transition(:ghost)).to be false
+    end
+
+    it 'raises invalid transition when strict mode is requested' do
+      expect { instance.transition(:indexed, strict: true) }
         .to raise_error(Legion::Gaia::Workflow::InvalidTransition)
     end
 
-    it 'still raises UnknownState (programmer error)' do
-      expect { instance.transition(:ghost) }
+    it 'raises unknown state when strict mode is requested' do
+      expect { instance.transition(:ghost, strict: true) }
         .to raise_error(Legion::Gaia::Workflow::UnknownState)
     end
   end

--- a/spec/legion/gaia_spec.rb
+++ b/spec/legion/gaia_spec.rb
@@ -555,6 +555,21 @@ RSpec.describe Legion::Gaia do
       expect(status[:mode]).to eq(:router)
       expect(status[:router_routes]).to eq(0)
     end
+
+    it 'boots agent bridge when worker_id is configured without router mode' do
+      settings = described_class.settings.merge(router: described_class.settings[:router].merge(
+        mode: false,
+        worker_id: 'worker-a'
+      ))
+      allow(described_class).to receive(:settings).and_return(settings)
+      mock_bridge = instance_double(Legion::Gaia::Router::AgentBridge, start: true, stop: true)
+      allow(Legion::Gaia::Router::AgentBridge).to receive(:new).with(worker_id: 'worker-a').and_return(mock_bridge)
+
+      described_class.boot(mode: :agent)
+
+      expect(Legion::Gaia::Router::AgentBridge).to have_received(:new).with(worker_id: 'worker-a')
+      expect(mock_bridge).to have_received(:start)
+    end
   end
 
   describe '.respond with agent_bridge' do
@@ -619,6 +634,25 @@ RSpec.describe Legion::Gaia do
       obs = described_class.partner_observations.first
       expect(obs[:bond_role]).to eq(:partner)
       expect(obs[:channel]).to eq(:teams)
+    end
+
+    it 'records the last channel and channel-native identity for known bonds' do
+      allow(Legion::Gaia::BondRegistry).to receive(:bond).and_call_original
+      Legion::Gaia::BondRegistry.reset!
+      Legion::Gaia::BondRegistry.register('aad-123', bond: :partner)
+
+      frame = Legion::Gaia::InputFrame.new(
+        content: 'hello',
+        channel_id: :teams,
+        auth_context: { aad_object_id: 'aad-123', user_id: 'teams-user-123' }
+      )
+      described_class.ingest(frame)
+
+      entry = Legion::Gaia::BondRegistry.partner_entry
+      expect(entry[:last_channel]).to eq(:teams)
+      expect(entry[:channel_identity]).to eq('teams-user-123')
+    ensure
+      Legion::Gaia::BondRegistry.reset!
     end
 
     it 'extracts identity from aad_object_id fallback' do


### PR DESCRIPTION
## Summary
- Fix the 2026-05-06 GAIA gap-analysis findings across advisory generation, Bot Framework issuer validation, router outbound/offline delivery, proactive dispatch targeting, notification gating, channel delivery, and shared-state synchronization.
- Replace `log.unknown` message traces with debug logging and normalize advisory/tool/routing data contracts.
- Bump `legion-gaia` to `0.9.52` with a changelog entry.

## Verification
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`

## Related
- Companion LLM executor PR consumes GAIA `tool_hint`, `suppress`, and `context_window` advisory data so Gap 1 is effective at provider-call time.