### PR TITLE
Fix NoMethodError in append_action_markers when intentions are Arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.55] - 2026-05-11
+
+### Fixed
+- `append_action_markers`: handle Array values for `new_intentions` and `active_intentions` — use `.size` for Arrays instead of calling `.to_i`, preventing `NoMethodError` when action selection returns intention lists rather than integer counts.
+
 ## [0.9.54] - 2026-05-09
 
 ### Removed

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -901,12 +901,21 @@ module Legion
         parts << "reflection=#{category}:#{truncate_text(observation, 48).inspect}"
       end
 
+      def count_marker_value(value)
+        return value.size if value.is_a?(Array)
+        return 0 unless value.respond_to?(:to_i)
+
+        value.to_i
+      end
+
       def append_action_markers(parts, action, tick_number)
         return unless action.is_a?(Hash)
 
-        new_intentions = action[:new_intentions].to_i
+        new_intentions = count_marker_value(action[:new_intentions])
         parts << "intentions+#{new_intentions}" if new_intentions.positive?
-        parts << "active_intentions=#{action[:active_intentions]}" if action[:active_intentions].to_i.positive?
+        if count_marker_value(action[:active_intentions]).positive?
+          parts << "active_intentions=#{count_marker_value(action[:active_intentions])}"
+        end
         parts << "drive=#{action[:dominant_drive]}" if action[:dominant_drive]
         append_action_goal_marker(parts, action)
 

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.54'
+    VERSION = '0.9.55'
   end
 end


### PR DESCRIPTION
## Summary

- Adds `count_marker_value` private helper that returns `.size` for Arrays and `.to_i` for integer-like values, falling back to `0` for anything else
- Replaces both direct `.to_i` calls on `action[:new_intentions]` and `action[:active_intentions]` in `append_action_markers` with `count_marker_value`
- Prevents `NoMethodError: undefined method 'to_i' for an instance of Array` seen in production (gem 0.9.54) when action selection returns intention lists rather than counts

## Test plan

- [ ] Full RSpec suite passes (`bundle exec rspec`) — verified green
- [ ] RuboCop clean (`bundle exec rubocop -A`) — auto-corrected one line-length offense, exit 0
- [ ] Verify `count_marker_value([intent1, intent2])` returns `2`
- [ ] Verify `count_marker_value(3)` returns `3`
- [ ] Verify `count_marker_value(nil)` returns `0`