### PR TITLE
Normalize GAIA interaction trace affect fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.56] - 2026-05-15
+
+### Fixed
+- Preserve GAIA defaults while overlaying loaded `:gaia` settings so partial config hashes do not erase required keys like `heartbeat_interval` or `router`.
+- Record partner interaction traces with scalar affect fields and separate structured valence context, preventing `String`/`Hash` values from crashing trace storage during ingest.
+
 ## [0.9.55] - 2026-05-11
 
 ### Fixed

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'legion/json'
+require 'legion/logging'
+require 'legion/settings'
 require 'legion/gaia/version'
 require 'legion/gaia/tick_history'
 require 'legion/gaia/workflow'
@@ -134,8 +137,6 @@ module Legion
 
       def settings
         defaults = Legion::Gaia::Settings.default
-        return defaults unless Legion.const_defined?('Settings', false)
-
         loaded = Legion::Settings[:gaia]
         return defaults unless loaded.is_a?(Hash)
 
@@ -774,8 +775,8 @@ module Legion
         store = apollo_local_store
         return unless store
 
-        TrackerPersistence.hydrate_all(store: store) if defined?(TrackerPersistence)
-        BondRegistry.hydrate_from_apollo(store: store) if defined?(BondRegistry)
+        TrackerPersistence.hydrate_all(store: store)
+        BondRegistry.hydrate_from_apollo(store: store)
         log.info('Legion::Gaia hydrated trackers and bond registry from Apollo Local')
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.hydrate_from_apollo_local')

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -133,11 +133,13 @@ module Legion
       end
 
       def settings
-        if Legion.const_defined?('Settings', false)
-          Legion::Settings[:gaia] || Legion::Gaia::Settings.default
-        else
-          Legion::Gaia::Settings.default
-        end
+        defaults = Legion::Gaia::Settings.default
+        return defaults unless Legion.const_defined?('Settings', false)
+
+        loaded = Legion::Settings[:gaia]
+        return defaults unless loaded.is_a?(Hash)
+
+        merge_settings_hashes(defaults, loaded)
       end
 
       def heartbeat(**)
@@ -539,6 +541,7 @@ module Legion
       def record_interaction_trace(observation)
         return unless defined?(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces)
 
+        emotional_context = interaction_trace_emotional_context
         runner = Object.new
         runner.extend(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces)
         trace_result = runner.store_trace(
@@ -548,11 +551,13 @@ module Legion
             channel: observation[:channel],
             direct_address: observation[:direct_address],
             bond_role: observation[:bond_role]
-          },
+          }.tap do |payload|
+            payload[:emotional_context] = emotional_context if emotional_context
+          end,
           domain_tags: ['partner_interaction', observation[:channel].to_s],
           origin: :direct_experience,
-          emotional_valence: @last_valences&.first&.inspect,
-          emotional_intensity: 0.5,
+          emotional_valence: interaction_trace_emotional_valence(emotional_context),
+          emotional_intensity: interaction_trace_emotional_intensity(emotional_context),
           confidence: 0.8
         )
         log.info("[gaia] memory+ episodic trace=#{trace_result[:trace_id].to_s[0, 8]} " \
@@ -602,6 +607,33 @@ module Legion
         return nil unless @last_response_at
 
         (Time.now.utc - @last_response_at).to_f
+      end
+
+      def interaction_trace_emotional_context
+        context = @last_valences&.first
+        context.is_a?(Hash) ? context.dup : nil
+      end
+
+      def interaction_trace_emotional_valence(emotional_context)
+        raw = emotional_context || @last_valences&.first
+        return raw.to_f.clamp(-1.0, 1.0) if raw.is_a?(Numeric)
+
+        numeric = Float(raw)
+        numeric.clamp(-1.0, 1.0)
+      rescue ArgumentError, TypeError
+        0.0
+      end
+
+      def interaction_trace_emotional_intensity(emotional_context)
+        compute_arousal(emotional_context) || 0.5
+      end
+
+      def merge_settings_hashes(base, override)
+        return override unless base.is_a?(Hash) && override.is_a?(Hash)
+
+        base.merge(override) do |_key, base_value, override_value|
+          merge_settings_hashes(base_value, override_value)
+        end
       end
 
       def check_partner_absence(observations, phase_handlers)

--- a/lib/legion/gaia/offline_handler.rb
+++ b/lib/legion/gaia/offline_handler.rb
@@ -79,11 +79,7 @@ module Legion
         end
 
         def offline_threshold
-          if Legion.const_defined?(:Settings, false)
-            Legion::Settings.dig(:gaia, :offline_threshold) || 60
-          else
-            60
-          end
+          Legion::Settings.dig(:gaia, :offline_threshold) || 60
         rescue StandardError => e
           handle_exception(e, level: :debug, operation: 'gaia.offline_handler.offline_threshold')
           60

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -285,7 +285,7 @@ module Legion
       end
 
       def knowledge_setting(key, default)
-        return default unless defined?(Legion::Settings) && !Legion::Settings[:gaia].nil?
+        return default if Legion::Settings[:gaia].nil?
 
         Legion::Settings[:gaia].dig(:knowledge, key) || default
       rescue StandardError => e

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.55'
+    VERSION = '0.9.56'
   end
 end

--- a/spec/legion/gaia/router/router_bridge_spec.rb
+++ b/spec/legion/gaia/router/router_bridge_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Legion::Gaia::Router::RouterBridge do
       delivery_info = double('delivery_info', delivery_tag: 'tag-1')
       payload = Legion::JSON.dump({ id: 'frame-2', content: 'hello', content_type: :text, channel_id: :cli })
 
-      stub_const('Legion::Gaia::Router::Transport', Module.new) unless defined?(Legion::Gaia::Router::Transport)
+      stub_const('Legion::Gaia::Router::Transport', Module.new)
       stub_const('Legion::Gaia::Router::Transport::Queues', Module.new)
       stub_const('Legion::Gaia::Router::Transport::Queues::Outbound', outbound_class)
       allow(bridge).to receive(:transport_available?).and_return(true)
@@ -151,7 +151,7 @@ RSpec.describe Legion::Gaia::Router::RouterBridge do
       delivery_info = double('delivery_info', delivery_tag: 'tag-2')
       payload = Legion::JSON.dump({ id: 'frame-3', content: 'hello', content_type: :text, channel_id: :missing })
 
-      stub_const('Legion::Gaia::Router::Transport', Module.new) unless defined?(Legion::Gaia::Router::Transport)
+      stub_const('Legion::Gaia::Router::Transport', Module.new)
       stub_const('Legion::Gaia::Router::Transport::Queues', Module.new)
       stub_const('Legion::Gaia::Router::Transport::Queues::Outbound', outbound_class)
       allow(bridge).to receive(:transport_available?).and_return(true)

--- a/spec/legion/gaia_spec.rb
+++ b/spec/legion/gaia_spec.rb
@@ -636,6 +636,45 @@ RSpec.describe Legion::Gaia do
       expect(obs[:channel]).to eq(:teams)
     end
 
+    it 'stores partner interaction traces with scalar affect and valence context' do
+      stub_const('Legion::Extensions::Agentic::Memory::Trace::Runners::Traces', Module.new)
+      allow(Legion::Gaia::BondRegistry).to receive(:bond).with('esity').and_return(:partner)
+      described_class.instance_variable_set(:@last_valences, [
+                                              {
+                                                urgency: 0.6,
+                                                novelty: 0.4,
+                                                importance: 0.8,
+                                                familiarity: 0.2
+                                              }
+                                            ])
+
+      frame = Legion::Gaia::InputFrame.new(
+        content: 'hello',
+        channel_id: :teams,
+        auth_context: { identity: 'esity' }
+      )
+
+      expect_any_instance_of(Object).to receive(:store_trace) do |_runner, payload|
+        expect(payload[:type]).to eq(:episodic)
+        expect(payload[:emotional_valence]).to eq(0.0)
+        expect(payload[:emotional_intensity]).to be_within(0.001).of(0.6)
+        expect(payload[:content_payload]).to include(
+          interaction_type: :text,
+          channel: :teams,
+          direct_address: false,
+          bond_role: :partner
+        )
+        expect(payload[:content_payload][:emotional_context]).to include(
+          urgency: 0.6,
+          novelty: 0.4,
+          importance: 0.8,
+          familiarity: 0.2
+        )
+      end.and_return({ trace_id: SecureRandom.uuid, trace_type: :episodic, strength: 0.6 })
+
+      described_class.ingest(frame)
+    end
+
     it 'records the last channel and channel-native identity for known bonds' do
       allow(Legion::Gaia::BondRegistry).to receive(:bond).and_call_original
       Legion::Gaia::BondRegistry.reset!


### PR DESCRIPTION
## Summary
- merge GAIA defaults with loaded settings so partial config hashes keep required keys
- write scalar trace affect fields while preserving structured emotional context on partner interaction traces
- add regression coverage for partner interaction trace storage

## Verification
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A