### PR TITLE
feat(gaia): principal_id on signals, knowledge_retrieval access scope, TrackerPersistence identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.57] - 2026-05-15
+
+### Fixed
+- Stop GAIA dream-cycle knowledge promotion from storing consolidation-count bookkeeping in Apollo; maintenance summaries like `Consolidated N memory trace(s) to long-term storage` are no longer promoted as actionable knowledge.
+
 ## [0.9.56] - 2026-05-15
 
 ### Fixed

--- a/lib/legion/gaia/input_frame.rb
+++ b/lib/legion/gaia/input_frame.rb
@@ -16,7 +16,8 @@ module Legion
       :session_continuity_id,
       :auth_context,
       :metadata,
-      :received_at
+      :received_at,
+      :principal_id
     ) do
       def initialize(
         content:,
@@ -28,7 +29,8 @@ module Legion
         session_continuity_id: nil,
         auth_context: {},
         metadata: {},
-        received_at: Time.now.utc
+        received_at: Time.now.utc,
+        principal_id: nil
       )
         super
       end
@@ -45,14 +47,19 @@ module Legion
         metadata[:salience] || 0.0
       end
 
+      def resolved_principal_id
+        principal_id || auth_context&.dig(:principal_id)
+      end
+
       def to_signal
         {
-          value: content,
-          source_type: metadata[:source_type] || :ambient,
-          salience: salience,
-          channel_id: channel_id,
-          frame_id: id,
-          received_at: received_at
+          value:        content,
+          source_type:  metadata[:source_type] || :ambient,
+          salience:     salience,
+          channel_id:   channel_id,
+          frame_id:     id,
+          received_at:  received_at,
+          principal_id: resolved_principal_id
         }
       end
     end

--- a/lib/legion/gaia/input_frame.rb
+++ b/lib/legion/gaia/input_frame.rb
@@ -19,7 +19,7 @@ module Legion
       :received_at,
       :principal_id
     ) do
-      def initialize(
+      def initialize( # rubocop:disable Metrics/ParameterLists
         content:,
         channel_id:,
         id: SecureRandom.uuid,
@@ -53,12 +53,12 @@ module Legion
 
       def to_signal
         {
-          value:        content,
-          source_type:  metadata[:source_type] || :ambient,
-          salience:     salience,
-          channel_id:   channel_id,
-          frame_id:     id,
-          received_at:  received_at,
+          value: content,
+          source_type: metadata[:source_type] || :ambient,
+          salience: salience,
+          channel_id: channel_id,
+          frame_id: id,
+          received_at: received_at,
           principal_id: resolved_principal_id
         }
       end

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -100,10 +100,10 @@ module Legion
           end
 
           {
-            text:                    current_signal[:value] || current_signal[:content] || current_signal.to_s,
-            limit:                   knowledge_setting(:retrieval_limit, 5),
-            min_confidence:          knowledge_setting(:retrieval_min_confidence, 0.3),
-            tags:                    current_signal[:tags],
+            text: current_signal[:value] || current_signal[:content] || current_signal.to_s,
+            limit: knowledge_setting(:retrieval_limit, 5),
+            min_confidence: knowledge_setting(:retrieval_min_confidence, 0.3),
+            tags: current_signal[:tags],
             requesting_principal_id: current_signal[:principal_id]
           }
         },

--- a/lib/legion/gaia/phase_wiring.rb
+++ b/lib/legion/gaia/phase_wiring.rb
@@ -89,7 +89,8 @@ module Legion
           { limit: knowledge_setting(:memory_retrieval_limit, 10) }
         },
         knowledge_retrieval: lambda { |ctx|
-          current_signal = ctx[:signals]&.last
+          human_signal = ctx[:signals]&.select { |s| s.is_a?(Hash) && s[:source_type] == :human_direct }&.last
+          current_signal = human_signal || ctx[:signals]&.last
           memory_results = ctx.dig(:prior_results, :memory_retrieval)
           skip_threshold = knowledge_setting(:memory_skip_threshold, 0.8)
 
@@ -99,10 +100,11 @@ module Legion
           end
 
           {
-            text: current_signal[:value] || current_signal[:content] || current_signal.to_s,
-            limit: knowledge_setting(:retrieval_limit, 5),
-            min_confidence: knowledge_setting(:retrieval_min_confidence, 0.3),
-            tags: current_signal[:tags]
+            text:                    current_signal[:value] || current_signal[:content] || current_signal.to_s,
+            limit:                   knowledge_setting(:retrieval_limit, 5),
+            min_confidence:          knowledge_setting(:retrieval_min_confidence, 0.3),
+            tags:                    current_signal[:tags],
+            requesting_principal_id: current_signal[:principal_id]
           }
         },
         identity_entropy_check: ->(_ctx) { {} },
@@ -517,7 +519,6 @@ module Legion
         parts = [
           extract_association(prior_results[:association_walk]),
           extract_conflicts(prior_results[:contradiction_resolution]),
-          extract_consolidation(prior_results[:consolidation_commit]),
           extract_reflection(prior_results[:dream_reflection]),
           extract_agenda(prior_results[:agenda_formation])
         ].compact
@@ -558,12 +559,6 @@ module Legion
         return unless conflicts.is_a?(Hash) && conflicts[:resolved].to_i.positive?
 
         "Resolved #{conflicts[:resolved]} contradiction(s)"
-      end
-
-      def extract_consolidation(consol)
-        return unless consol.is_a?(Hash) && consol[:migrated].to_i.positive?
-
-        "Consolidated #{consol[:migrated]} memory trace(s) to long-term storage"
       end
 
       def extract_reflection(reflection)

--- a/lib/legion/gaia/router/agent_bridge.rb
+++ b/lib/legion/gaia/router/agent_bridge.rb
@@ -85,7 +85,8 @@ module Legion
             device_context: payload[:device_context] || {},
             session_continuity_id: payload[:session_continuity_id],
             auth_context: payload[:auth_context] || {},
-            metadata: payload[:metadata] || {}
+            metadata: payload[:metadata] || {},
+            principal_id: payload[:principal_id]
           )
         rescue StandardError => e
           handle_exception(e, level: :warn, operation: 'gaia.router.agent_bridge.reconstruct_input_frame',

--- a/lib/legion/gaia/router/transport/messages/input_frame_message.rb
+++ b/lib/legion/gaia/router/transport/messages/input_frame_message.rb
@@ -29,7 +29,8 @@ module Legion
                 session_continuity_id: frame.session_continuity_id,
                 auth_context: frame.auth_context,
                 metadata: frame.metadata,
-                received_at: frame.received_at.to_s
+                received_at: frame.received_at.to_s,
+                principal_id: frame.principal_id
               }
             end
 

--- a/lib/legion/gaia/tracker_persistence.rb
+++ b/lib/legion/gaia/tracker_persistence.rb
@@ -97,14 +97,14 @@ module Legion
         entries = tracker.to_apollo_entries
         results = entries.map do |entry|
           store.upsert(
-            content:                 entry[:content],
-            tags:                    entry[:tags],
-            source_channel:          'gaia',
-            confidence:              entry.fetch(:confidence, 0.9),
-            access_scope:            entry.fetch(:access_scope, 'global'),
+            content: entry[:content],
+            tags: entry[:tags],
+            source_channel: 'gaia',
+            confidence: entry.fetch(:confidence, 0.9),
+            access_scope: entry.fetch(:access_scope, 'global'),
             identity_canonical_name: entry[:identity_canonical_name],
-            identity_principal_id:   entry[:identity_principal_id],
-            identity_id:             entry[:identity_id]
+            identity_principal_id: entry[:identity_principal_id],
+            identity_id: entry[:identity_id]
           )
         end
 

--- a/lib/legion/gaia/tracker_persistence.rb
+++ b/lib/legion/gaia/tracker_persistence.rb
@@ -96,8 +96,16 @@ module Legion
       def flush_tracker(tracker, store:)
         entries = tracker.to_apollo_entries
         results = entries.map do |entry|
-          store.upsert(content: entry[:content], tags: entry[:tags],
-                       source_channel: 'gaia', confidence: entry.fetch(:confidence, 0.9))
+          store.upsert(
+            content:                 entry[:content],
+            tags:                    entry[:tags],
+            source_channel:          'gaia',
+            confidence:              entry.fetch(:confidence, 0.9),
+            access_scope:            entry.fetch(:access_scope, 'global'),
+            identity_canonical_name: entry[:identity_canonical_name],
+            identity_principal_id:   entry[:identity_principal_id],
+            identity_id:             entry[:identity_id]
+          )
         end
 
         unless results.all? { |result| upsert_succeeded?(result) }

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.56'
+    VERSION = '0.9.57'
   end
 end

--- a/spec/legion/gaia/input_frame_spec.rb
+++ b/spec/legion/gaia/input_frame_spec.rb
@@ -85,5 +85,46 @@ RSpec.describe Legion::Gaia::InputFrame do
       expect(signal[:channel_id]).to eq(:cli)
       expect(signal[:frame_id]).to eq(frame.id)
     end
+
+    it 'includes principal_id in the signal hash' do
+      frame = described_class.new(content: 'hello', channel_id: 'test', principal_id: 42)
+      expect(frame.to_signal[:principal_id]).to eq(42)
+    end
+
+    it 'includes nil principal_id when not set' do
+      frame = described_class.new(content: 'hello', channel_id: 'test')
+      expect(frame.to_signal[:principal_id]).to be_nil
+    end
+  end
+
+  describe 'principal_id' do
+    it 'defaults to nil when not provided' do
+      frame = described_class.new(content: 'hello', channel_id: 'test')
+      expect(frame.principal_id).to be_nil
+    end
+
+    it 'accepts an explicit integer principal_id' do
+      frame = described_class.new(content: 'hello', channel_id: 'test', principal_id: 42)
+      expect(frame.principal_id).to eq(42)
+    end
+  end
+
+  describe '#resolved_principal_id' do
+    it 'returns explicit principal_id when set' do
+      frame = described_class.new(content: 'hello', channel_id: 'test',
+                                  principal_id: 99, auth_context: { principal_id: 7 })
+      expect(frame.resolved_principal_id).to eq(99)
+    end
+
+    it 'falls back to auth_context[:principal_id] when principal_id is nil' do
+      frame = described_class.new(content: 'hello', channel_id: 'test',
+                                  auth_context: { principal_id: 7 })
+      expect(frame.resolved_principal_id).to eq(7)
+    end
+
+    it 'returns nil when neither is set' do
+      frame = described_class.new(content: 'hello', channel_id: 'test')
+      expect(frame.resolved_principal_id).to be_nil
+    end
   end
 end

--- a/spec/legion/gaia/phase_wiring_spec.rb
+++ b/spec/legion/gaia/phase_wiring_spec.rb
@@ -361,10 +361,9 @@ RSpec.describe Legion::Gaia::PhaseWiring do
       expect(content).to include('Resolved 3 contradiction(s)')
     end
 
-    it 'extracts consolidation migration counts' do
+    it 'does not promote consolidation migration counts by themselves' do
       results = { consolidation_commit: { migrated: 5 } }
-      content = described_class.build_promotion_content(results)
-      expect(content).to include('Consolidated 5 memory trace(s)')
+      expect(described_class.build_promotion_content(results)).to be_nil
     end
 
     it 'extracts dream reflection insights' do
@@ -460,6 +459,47 @@ RSpec.describe Legion::Gaia::PhaseWiring do
     end
   end
 
+  describe 'PHASE_ARGS[:knowledge_retrieval] requesting_principal_id' do
+    let(:arg_builder) { described_class::PHASE_ARGS[:knowledge_retrieval] }
+
+    let(:base_ctx) do
+      { signals: [{ value: 'what is ruby?', tags: [], principal_id: nil }],
+        prior_results: {} }
+    end
+
+    it 'includes requesting_principal_id from the signal when present' do
+      ctx = base_ctx.merge(
+        signals: [{ value: 'what is ruby?', source_type: :human_direct, tags: [], principal_id: 42 }]
+      )
+      args = arg_builder.call(ctx)
+      expect(args[:requesting_principal_id]).to eq(42)
+    end
+
+    it 'passes requesting_principal_id as nil when signal has no principal_id' do
+      ctx = base_ctx.merge(
+        signals: [{ value: 'test', source_type: :human_direct, tags: [] }]
+      )
+      args = arg_builder.call(ctx)
+      expect(args[:requesting_principal_id]).to be_nil
+    end
+
+    it 'returns skip hash (not raise) when signals is empty' do
+      args = arg_builder.call(base_ctx.merge(signals: []))
+      expect(args).to be_a(Hash)
+    end
+
+    it 'reads principal_id from the last human_direct signal, not the last signal overall' do
+      ctx = base_ctx.merge(
+        signals: [
+          { value: 'human query', tags: [], source_type: :human_direct, principal_id: 42 },
+          { value: 'system update', tags: [], source_type: :ambient, principal_id: nil }
+        ]
+      )
+      args = arg_builder.call(ctx)
+      expect(args[:requesting_principal_id]).to eq(42)
+    end
+  end
+
   describe 'PHASE_ARGS knowledge_promotion' do
     let(:builder) { described_class::PHASE_ARGS[:knowledge_promotion] }
 
@@ -476,6 +516,11 @@ RSpec.describe Legion::Gaia::PhaseWiring do
       expect(result[:content_type]).to eq(:observation)
       expect(result[:tags]).to include('dream_cycle')
       expect(result[:source_agent]).to eq('gaia')
+    end
+
+    it 'skips promotion when the only dream result is consolidation bookkeeping' do
+      ctx = { prior_results: { consolidation_commit: { migrated: 64 } } }
+      expect(builder.call(ctx)).to eq({ skip: true })
     end
   end
 

--- a/spec/legion/gaia/tracker_persistence_spec.rb
+++ b/spec/legion/gaia/tracker_persistence_spec.rb
@@ -107,6 +107,70 @@ RSpec.describe Legion::Gaia::TrackerPersistence do
     end
   end
 
+  describe '.flush_tracker (entry-provided identity)' do
+    before { described_class.reset! }
+
+    it 'passes entry-provided access_scope and identity to store.upsert' do
+      tracker = double('tracker', dirty?: true, mark_clean!: nil,
+                       to_apollo_entries: [
+                         { content: '{"pref":"direct"}', tags: %w[preference],
+                           access_scope: 'private', identity_principal_id: 42,
+                           identity_id: 99, identity_canonical_name: 'alice' }
+                       ])
+      store = double('store')
+      described_class.register_tracker(:prefs, tracker: tracker, tags: ['preference'])
+
+      expect(store).to receive(:upsert).with(
+        hash_including(
+          access_scope:            'private',
+          identity_principal_id:   42,
+          identity_id:             99,
+          identity_canonical_name: 'alice'
+        )
+      ).and_return({ success: true })
+
+      described_class.flush_dirty(store: store)
+    end
+
+    it 'falls back to global access_scope when entry does not specify it' do
+      tracker = double('tracker', dirty?: true, mark_clean!: nil,
+                       to_apollo_entries: [
+                         { content: '{}', tags: %w[test] }
+                       ])
+      store = double('store')
+      described_class.register_tracker(:test, tracker: tracker, tags: ['test'])
+
+      expect(store).to receive(:upsert).with(
+        hash_including(access_scope: 'global')
+      ).and_return({ success: true })
+
+      described_class.flush_dirty(store: store)
+    end
+
+    it 'does not overwrite entry identity with process identity when entry provides identity' do
+      stub_const('Legion::Identity::Process', Module.new do
+        extend self
+        define_method(:identity_hash) do
+          { canonical_name: 'system', db_principal_id: 1, db_identity_id: 1 }
+        end
+      end)
+
+      tracker = double('tracker', dirty?: true, mark_clean!: nil,
+                       to_apollo_entries: [
+                         { content: '{}', tags: %w[test],
+                           identity_principal_id: 42, identity_canonical_name: 'alice' }
+                       ])
+      store = double('store')
+      described_class.register_tracker(:test, tracker: tracker, tags: ['test'])
+
+      expect(store).to receive(:upsert).with(
+        hash_including(identity_principal_id: 42, identity_canonical_name: 'alice')
+      ).and_return({ success: true })
+
+      described_class.flush_dirty(store: store)
+    end
+  end
+
   describe '.should_flush?' do
     it 'returns true when never flushed' do
       expect(described_class.should_flush?).to be true

--- a/spec/legion/gaia/tracker_persistence_spec.rb
+++ b/spec/legion/gaia/tracker_persistence_spec.rb
@@ -112,19 +112,19 @@ RSpec.describe Legion::Gaia::TrackerPersistence do
 
     it 'passes entry-provided access_scope and identity to store.upsert' do
       tracker = double('tracker', dirty?: true, mark_clean!: nil,
-                       to_apollo_entries: [
-                         { content: '{"pref":"direct"}', tags: %w[preference],
-                           access_scope: 'private', identity_principal_id: 42,
-                           identity_id: 99, identity_canonical_name: 'alice' }
-                       ])
+                                  to_apollo_entries: [
+                                    { content: '{"pref":"direct"}', tags: %w[preference],
+                                      access_scope: 'private', identity_principal_id: 42,
+                                      identity_id: 99, identity_canonical_name: 'alice' }
+                                  ])
       store = double('store')
       described_class.register_tracker(:prefs, tracker: tracker, tags: ['preference'])
 
       expect(store).to receive(:upsert).with(
         hash_including(
-          access_scope:            'private',
-          identity_principal_id:   42,
-          identity_id:             99,
+          access_scope: 'private',
+          identity_principal_id: 42,
+          identity_id: 99,
           identity_canonical_name: 'alice'
         )
       ).and_return({ success: true })
@@ -134,9 +134,9 @@ RSpec.describe Legion::Gaia::TrackerPersistence do
 
     it 'falls back to global access_scope when entry does not specify it' do
       tracker = double('tracker', dirty?: true, mark_clean!: nil,
-                       to_apollo_entries: [
-                         { content: '{}', tags: %w[test] }
-                       ])
+                                  to_apollo_entries: [
+                                    { content: '{}', tags: %w[test] }
+                                  ])
       store = double('store')
       described_class.register_tracker(:test, tracker: tracker, tags: ['test'])
 
@@ -150,16 +150,17 @@ RSpec.describe Legion::Gaia::TrackerPersistence do
     it 'does not overwrite entry identity with process identity when entry provides identity' do
       stub_const('Legion::Identity::Process', Module.new do
         extend self
+
         define_method(:identity_hash) do
           { canonical_name: 'system', db_principal_id: 1, db_identity_id: 1 }
         end
       end)
 
       tracker = double('tracker', dirty?: true, mark_clean!: nil,
-                       to_apollo_entries: [
-                         { content: '{}', tags: %w[test],
-                           identity_principal_id: 42, identity_canonical_name: 'alice' }
-                       ])
+                                  to_apollo_entries: [
+                                    { content: '{}', tags: %w[test],
+                                      identity_principal_id: 42, identity_canonical_name: 'alice' }
+                                  ])
       store = double('store')
       described_class.register_tracker(:test, tracker: tracker, tags: ['test'])
 


### PR DESCRIPTION
## Summary

- `InputFrame` now carries `principal_id` (explicit integer) + `resolved_principal_id` (falls back to `auth_context[:principal_id]`)
- `InputFrame#to_signal` includes `principal_id:` so it survives through `SensoryBuffer` → `signals` array into the tick context
- `PHASE_ARGS[:knowledge_retrieval]` selects the last `human_direct` signal (falls back to last signal overall) and reads `principal_id` from it, passing as `requesting_principal_id:` — flows through legion-apollo → lex-apollo where the SQL filter enforces global/team/private scope
- `TrackerPersistence#flush_tracker` now passes entry-provided `access_scope`, `identity_principal_id`, `identity_id`, `identity_canonical_name` directly to `store.upsert` — does NOT resolve `Identity::Process` at flush time (avoids stamping wrong identity on accumulated entries). legion-apollo's `inject_identity_context` fills nil identity fields as a fallback.

## Prerequisites

- Phase 0 (legion-apollo identity injection) merged
- Phase 2 (legion-transport integer headers) merged
- Phase 3a (lex-apollo access_scope SQL filter) merged

## Test plan

- [ ] InputFrame: principal_id defaults nil, accepts explicit value, resolved_principal_id falls back to auth_context
- [ ] InputFrame#to_signal: includes principal_id
- [ ] PhaseWiring: knowledge_retrieval args include requesting_principal_id from last human_direct signal (not last signal overall)
- [ ] TrackerPersistence: entry-provided identity/scope passed through to store.upsert unchanged
- [ ] TrackerPersistence: global scope default when entry omits access_scope
- [ ] TrackerPersistence: entry identity not overwritten by process identity
- [ ] All existing examples pass