### PR TITLE
README: the experimental layer, shown working

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,43 +82,25 @@ have different confidence constants. Do not conflate them.
 - Tick history is an **in-memory, 200-entry ring buffer** recording `{ timestamp, phase, duration_ms,
   status }` per phase. This is not database-persisted — restart the process and it is gone.
 
-## Measured, From a Production Deployment
+## Measured, From the Maintainer's Development Instance
 
-The numbers below come from one production deployment of the framework, not a benchmark suite.
-Date windows and provenance are stated next to each figure; treat this as evidence from a single
-running instance, not a generalizable result.
+The numbers below come from the maintainer's long-running development instance of the framework,
+not a benchmark suite. Date windows and provenance are stated next to each figure; treat this as
+evidence from a single running instance, not a generalizable result.
 
 **A reinforcement-learning receipt.** A GAIA advisory weight learned from `0.5` to `0.535` across
 scored reaction events, recorded in a timestamped ledger entry. This is the smallest verifiable
 unit of "the layer learned something" available today.
 
-**Production Postgres (window 2026-03-26 to 2026-05-30):**
+**Maintainer's development instance (83 days, 2026-04-10 to 2026-07-02):**
 
-| Memory type | Traces |
-|---|---|
-| Episodic | 4,181,871 |
-| Semantic | 76,088 |
-| Sensory | 2,557 |
-| Identity | 2,554 |
-| Procedural | 1,818 |
-| **Total** | **4,262,888** |
-
-- 2,897,670 memory co-activation pairs.
-- 53,686 contradictions detected and linked.
-- 208 similarity relations with learned weight variance (range 0.900–0.99996, average 0.926).
-- 33,862 identity resolutions: 16,972 Entra-verified, 16,890 cache-served, 217 unverified, 65
-  canonical changes.
-
-**Local SQLite (83 days, 2026-04-10 to 2026-07-02):**
-
-- 133,585 traces, every one decayed at least once.
+- 133,585 memory traces, every one decayed at least once.
 - 3,407 reinforced.
 - Maximum reinforcement count on a single trace: 37.
 
 **A note on contradiction weights.** Contradiction links carry a *fixed* assigned weight of `0.8` —
 this is a flag for downstream resolution, not a learned value. Do not read it as evidence of
-learning. The learned variance lives in the similarity relations above (0.900–0.99996) and in the
-0.5 -> 0.535 advisory weight artifact.
+learning. The learned variance lives in the 0.5 -> 0.535 advisory weight artifact above.
 
 ## The Loop With the LLM Layer
 
@@ -129,16 +111,16 @@ on it. GAIA does not inject prompts itself.
 
 ## Honest Boundaries
 
-- All measured numbers above come from a single production deployment, not a benchmark suite —
-  treat them as evidence from one running instance, not a general claim about the approach.
+- All measured numbers above come from the maintainer's own development instance, not a benchmark
+  suite and not any operational deployment — treat them as evidence from one running instance, not
+  a general claim about the approach.
 - Some mechanisms have code but no accumulated data yet: the entity-relationship graph tables are
-  empty in the measured deployment, and mind-growth proposals persist only to a 7-day cache TTL, so
+  empty in the measured instance, and mind-growth proposals persist only to a 7-day cache TTL, so
   there is no long-horizon record of them yet.
 - Tick history is in-memory only (see the 200-entry ring buffer above) — it does not survive a
   restart, and there is currently no persisted long-run tick record.
 - Whether this coordination layer earns its keep — whether reinforcement and decay measurably
-  improve routing over the plain job engine — is an open research question. It is being run in
-  production specifically to answer that question, not because the answer is already known.
+  improve routing over the plain job engine — is an open research question.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Legion::Gaia
 
-GAIA is the cognitive coordination layer for LegionIO. It turns channel input, extension runners, memory, notification policy, and router transport into one continuously ticking agent runtime.
+GAIA is the coordination layer for LegionIO's experimental agentic extensions. It turns channel
+input, extension runners, memory, notification policy, and router transport into one continuously
+ticking agent runtime. The layer is research: the open question is whether a job engine improves
+when successful task-routes strengthen and unused ones decay. GAIA is optional — the core LegionIO
+job engine runs without it, and none of its cognitive mechanics activate unless it is installed.
 
 **Version:** 0.9.50
 
@@ -38,6 +42,97 @@ The registry resolves runners from the loaded LegionIO extension set and builds 
 - `elapsed_ms`: monotonic elapsed time in milliseconds
 
 Those fields feed `/api/gaia/ticks` for operator-facing tick stream observability.
+
+## The Mechanics, From Source
+
+GAIA itself does not implement learning — it schedules and wires the extensions that do. The
+formulas below live in the sibling gems GAIA coordinates, and are cited here so the claims can be
+checked against source rather than taken on faith.
+
+**Connection reinforcement — [`lex-synapse`](https://github.com/LegionIO/lex-synapse):**
+
+- Connection confidence: `+0.02` per success, `-0.05` per failure, `-0.03` per validation failure.
+- Consecutive-success bonus: `+0.05` after 50 consecutive successes.
+- Idle decay: `confidence * 0.998^hours`.
+- Autonomy ladder, driven by confidence: `observe` 0.0–0.3, `filter` 0.3–0.6, `transform` 0.6–0.8,
+  `autonomous` 0.8–1.0.
+- Auto-revert: after exactly 3 consecutive failures, the mutation's recorded `before_state` is
+  restored automatically.
+
+**Knowledge confidence — [`legion-apollo`](https://github.com/LegionIO/legion-apollo):**
+
+- New knowledge starts at confidence `0.5` with status `candidate`.
+- Corroboration adds `+0.3 * weight`, but only when a `>= 0.9` cosine-similar entry arrives from a
+  *different* provider than the original.
+- Retrieval adds `+0.02` to confidence.
+- Power-law time decay begins after 168 hours of inactivity.
+- Entries archive below confidence `0.05`.
+- Lifecycle: `candidate` -> `confirmed` -> `disputed` -> `archived`.
+
+**Tick scheduling — `lex-tick` constants:**
+
+- 16 full-active phases, 10 dream phases.
+- 4 modes with fixed time budgets: `dormant` 0.2s, `sentinel` 0.5s, `full` and `dream` 5.0s each.
+- Tick history is an **in-memory, 200-entry ring buffer** recording `{ timestamp, phase, duration_ms,
+  status }` per phase. This is not database-persisted — restart the process and it is gone.
+
+## Measured, From a Production Deployment
+
+The numbers below come from one production deployment of the framework, not a benchmark suite.
+Date windows and provenance are stated next to each figure; treat this as evidence from a single
+running instance, not a generalizable result.
+
+**A reinforcement-learning receipt.** A GAIA advisory weight learned from `0.5` to `0.535` across
+scored reaction events, recorded in a timestamped ledger entry. This is the smallest verifiable
+unit of "the layer learned something" available today.
+
+**Production Postgres (window 2026-03-26 to 2026-05-30):**
+
+| Memory type | Traces |
+|---|---|
+| Episodic | 4,181,871 |
+| Semantic | 76,088 |
+| Sensory | 2,557 |
+| Identity | 2,554 |
+| Procedural | 1,818 |
+| **Total** | **4,262,888** |
+
+- 2,897,670 memory co-activation pairs.
+- 53,686 contradictions detected and linked.
+- 208 similarity relations with learned weight variance (range 0.900–0.99996, average 0.926).
+- 33,862 identity resolutions: 16,972 Entra-verified, 16,890 cache-served, 217 unverified, 65
+  canonical changes.
+
+**Local SQLite (83 days, 2026-04-10 to 2026-07-02):**
+
+- 133,585 traces, every one decayed at least once.
+- 3,407 reinforced.
+- Maximum reinforcement count on a single trace: 37.
+
+**A note on contradiction weights.** Contradiction links carry a *fixed* assigned weight of `0.8` —
+this is a flag for downstream resolution, not a learned value. Do not read it as evidence of
+learning. The learned variance lives in the similarity relations above (0.900–0.99996) and in the
+0.5 -> 0.535 advisory weight artifact.
+
+## The Loop With the LLM Layer
+
+GAIA's own retrieval lands in tick context and executive goal formation — it does not touch LLM
+requests directly. Injection of Apollo knowledge into LLM requests happens in `legion-llm`'s
+pipeline, via the `rag_context` and `gaia_advisory` steps: the pipeline pulls context, GAIA advises
+on it. GAIA does not inject prompts itself.
+
+## Honest Boundaries
+
+- All measured numbers above come from a single production deployment, not a benchmark suite —
+  treat them as evidence from one running instance, not a general claim about the approach.
+- Some mechanisms have code but no accumulated data yet: the entity-relationship graph tables are
+  empty in the measured deployment, and mind-growth proposals persist only to a 7-day cache TTL, so
+  there is no long-horizon record of them yet.
+- Tick history is in-memory only (see the 200-entry ring buffer above) — it does not survive a
+  restart, and there is currently no persisted long-run tick record.
+- Whether this coordination layer earns its keep — whether reinforcement and decay measurably
+  improve routing over the plain job engine — is an open research question. It is being run in
+  production specifically to answer that question, not because the answer is already known.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,21 @@ checked against source rather than taken on faith.
 - Auto-revert: after exactly 3 consecutive failures, the mutation's recorded `before_state` is
   restored automatically.
 
-**Knowledge confidence — [`legion-apollo`](https://github.com/LegionIO/legion-apollo):**
+**Knowledge confidence — two tiers, two gems:**
 
-- New knowledge starts at confidence `0.5` with status `candidate`.
-- Corroboration adds `+0.3 * weight`, but only when a `>= 0.9` cosine-similar entry arrives from a
-  *different* provider than the original.
-- Retrieval adds `+0.02` to confidence.
-- Power-law time decay begins after 168 hours of inactivity.
-- Entries archive below confidence `0.05`.
-- Lifecycle: `candidate` -> `confirmed` -> `disputed` -> `archived`.
+Apollo knowledge is split across a local per-node store and a shared cross-node store, and the two
+have different confidence constants. Do not conflate them.
+
+- Local store — [`legion-apollo`](https://github.com/LegionIO/legion-apollo)
+  (`lib/legion/apollo/helpers/confidence.rb`): new knowledge starts at confidence `0.5`,
+  corroboration adds `+0.15`, decay rate is `0.005`, entries archive below confidence `0.1`.
+  Lifecycle: `pending` -> `confirmed` -> `disputed` -> `deprecated` -> `archived`.
+- Shared store — [`lex-apollo`](https://github.com/LegionIO/lex-apollo)
+  (`lib/legion/extensions/apollo/helpers/confidence.rb`): new knowledge starts at confidence `0.5`,
+  corroboration adds `+0.3 * weight` when a `>= 0.9` cosine-similar entry arrives from a *different*
+  provider (weight is halved for a same-provider match), retrieval adds `+0.02`, power-law time
+  decay begins after 168 hours of inactivity, and entries archive below confidence `0.05`.
+  Lifecycle: `candidate` -> `confirmed` -> `disputed` -> `decayed` -> `archived`.
 
 **Tick scheduling — `lex-tick` constants:**
 


### PR DESCRIPTION
## Summary

- Reframes GAIA's README around the "shown working" standard: every number in the new sections traces to either a named source constant in a sibling gem (lex-synapse, legion-apollo, lex-tick) or an owner-verified production aggregate with a stated date window and single-deployment provenance.
- Adds four sections: **The Mechanics, From Source** (reinforcement/decay/lifecycle formulas, cited to sibling repos), **Measured, From a Production Deployment** (the 0.5 -> 0.535 advisory-weight receipt, Postgres trace/co-activation/contradiction/identity-resolution aggregates for 2026-03-26 to 2026-05-30, local SQLite decay/reinforcement stats for the 83-day window), **The Loop With the LLM Layer** (clarifies GAIA advises, legion-llm's pipeline injects — GAIA does not touch prompts directly), and **Honest Boundaries** (single-deployment caveat, empty graph tables, 7-day mind-growth cache TTL, in-memory-only tick history, open research question framing).
- Explicitly flags the fixed 0.8 contradiction-link weight as a resolution flag, not a learned value, to avoid conflating it with the actual learned-weight variance (similarity relations, advisory weight).
- Installation, Basic Usage, Configuration, Cognitive Phases, HTTP API, Channel Adapters, Notification Gate, Router Mode, Shutdown Semantics, Operational Notes, and Development sections are unchanged.

## Test plan

- [x] Diff reviewed — additive only, no existing sections altered besides the opening summary paragraph.
- [x] Grepped for company/org references (UHG/Optum/UHC/United Health) — none present.
- [x] No code changes; README-only PR.