### PR TITLE
feat(loop): behavioral synapses — store, attribution spine, grading path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.60] - 2026-07-16
+### Added
+- H2: BehavioralSynapse store with vendored Confidence math (lifecycle: crystallize, lazy decay with intensity resistance, grade via record_outcome, pain at 3 consecutive failures → dampened + event emission)
+- `record_response_applied` public method — attribution facade for legion-llm's final-delivery hook; persists to Apollo Local with self-knowledge/attribution tags
+- Grading path in `evaluate_calibration`: reaction_score >= 0.6 → :success, <= 0.4 → :failure; maps each applied synapse_id via BehavioralSynapse.record_outcome scaled by imprint multiplier
+- TrackerPersistence integration for BehavioralSynapse: Tracker wrapper, hydrate at boot alongside bonds, flush_dirty/flush_all on heartbeat/shutdown
+
 ## [0.9.59] - 2026-07-16
 ### Added
 - H0: Partner identity as first-class store dimension — `record_interaction_trace` adds `partner:<identity>` domain tag; `SessionStore#erase_partner!(identity:)`; `AuditObserver` tool patterns keyed per-identity with `tool_patterns_for(identity)` and `erase_partner!(identity:)`; `TrackerPersistence.register_tracker` is idempotent (re-registration is a no-op, safe for partial-boot resume); fail-closed: no partner state written to shared Postgres when Apollo local is unavailable

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -32,6 +32,7 @@ require 'legion/gaia/proactive'
 require 'legion/gaia/offline_handler'
 require 'legion/gaia/proactive_dispatcher'
 require 'legion/gaia/bond_registry'
+require 'legion/gaia/behavioral_synapse'
 require 'legion/gaia/tracker_persistence'
 require 'legion/gaia/router'
 
@@ -118,6 +119,7 @@ module Legion
         @absence_pattern_checked_at = nil
         @last_valences = nil
         @last_response_at = nil
+        @last_applied = nil
         @tick_history = nil
         @tick_count = nil
         @started_at = nil
@@ -258,6 +260,28 @@ module Legion
         handle_exception(e, level: :warn, operation: 'gaia.record_advisory_meta', advisory_id: advisory_id)
       end
 
+      def record_response_applied(advisory_id:, identity:, applied:)
+        return unless started?
+
+        synapse_count = Array(applied[:behavioral_synapse_ids]).size
+        log.info("[gaia] attribution advisory_id=#{advisory_id} identity=#{identity} synapses=#{synapse_count}")
+
+        store = apollo_local_store
+        store&.upsert(
+          content: Legion::JSON.dump(applied.merge(advisory_id: advisory_id, identity: identity)),
+          tags: %w[self-knowledge attribution] + ["partner:#{identity}"],
+          source_channel: 'gaia',
+          confidence: 0.9,
+          access_scope: 'local'
+        )
+
+        @last_applied = applied.merge(advisory_id: advisory_id, identity: identity)
+        { recorded: true, advisory_id: advisory_id }
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'gaia.record_response_applied', advisory_id: advisory_id)
+        { recorded: false }
+      end
+
       def status
         return { started: false } unless started?
 
@@ -377,6 +401,7 @@ module Legion
         @registry.discover
         boot_channels
         boot_agent_bridge
+        register_behavioral_synapse_tracker
         hydrate_from_apollo_local
         register_provisional_partner_prior
         log.info('Legion::Gaia agent mode boot complete')
@@ -638,6 +663,8 @@ module Legion
           log.info("[gaia] calibration identity=#{observation[:identity]} " \
                    "deltas=#{result[:deltas].keys.join(',')}")
         end
+
+        grade_behavioral_synapses(result) if result.is_a?(Hash) && result[:reaction_score]
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.evaluate_calibration', identity: observation[:identity])
       end
@@ -653,6 +680,31 @@ module Legion
           tags: %w[bond calibration]
         )
         @calibration_runner = runner
+      end
+
+      def grade_behavioral_synapses(calibration_result)
+        return unless @last_applied.is_a?(Hash)
+
+        synapse_ids = Array(@last_applied[:behavioral_synapse_ids])
+        return if synapse_ids.empty?
+
+        reaction_score = calibration_result[:reaction_score].to_f
+        outcome = if reaction_score >= 0.6
+                    :success
+                  elsif reaction_score <= 0.4
+                    :failure
+                  end
+        return unless outcome
+
+        multiplier = fetch_imprint_multiplier
+        synapse_ids.each do |sid|
+          BehavioralSynapse.record_outcome(id: sid, outcome: outcome, multiplier: multiplier)
+        end
+        log.info("[gaia] graded synapses count=#{synapse_ids.size} outcome=#{outcome} " \
+                 "reaction_score=#{reaction_score.round(3)}")
+        @last_applied = nil
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'gaia.grade_behavioral_synapses')
       end
 
       def fetch_imprint_multiplier
@@ -835,12 +887,21 @@ module Legion
         handle_exception(e, level: :debug, operation: 'gaia.flush_trackers_on_shutdown')
       end
 
+      def register_behavioral_synapse_tracker
+        TrackerPersistence.register_tracker(
+          :behavioral_synapse,
+          tracker: BehavioralSynapse::Tracker.new,
+          tags: %w[self-knowledge behavior]
+        )
+      end
+
       def hydrate_from_apollo_local
         store = apollo_local_store
         return unless store
 
         TrackerPersistence.hydrate_all(store: store)
         BondRegistry.hydrate_from_apollo(store: store)
+        BehavioralSynapse.from_apollo(store: store)
         log.info('Legion::Gaia hydrated trackers and bond registry from Apollo Local')
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.hydrate_from_apollo_local')

--- a/lib/legion/gaia/behavioral_synapse.rb
+++ b/lib/legion/gaia/behavioral_synapse.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require 'concurrent/hash'
+require 'securerandom'
+require 'legion/json'
+require 'legion/logging/helper'
+
+module Legion
+  module Gaia
+    module BehavioralSynapse # rubocop:disable Metrics/ModuleLength
+      extend Legion::Logging::Helper
+
+      TO_APOLLO_TAGS = %w[self-knowledge behavior].freeze
+
+      # Vendored confidence math — identical constants to Legion::Extensions::Synapse::Helpers::Confidence.
+      # At runtime we delegate to the real module if it is loaded.
+      module Math
+        STARTING_SCORES = { explicit: 0.7, emergent: 0.3, seeded: 0.5 }.freeze
+        ADJUSTMENTS     = {
+          success: 0.02,
+          failure: -0.05,
+          validation_failure: -0.03,
+          consecutive_bonus: 0.05
+        }.freeze
+        DECAY_RATE = 0.998
+        CONSECUTIVE_BONUS_THRESHOLD = 50
+        AUTONOMY_RANGES = {
+          observe: 0.0..0.3,
+          filter: 0.3..0.6,
+          transform: 0.6..0.8,
+          autonomous: 0.8..1.0
+        }.freeze
+        E_WEIGHT = 3.0
+
+        module_function
+
+        def starting_score(origin)
+          STARTING_SCORES.fetch(origin.to_sym, 0.3)
+        end
+
+        def adjust(confidence, event, consecutive_successes: 0)
+          delta = ADJUSTMENTS.fetch(event.to_sym, 0.0)
+          delta += ADJUSTMENTS[:consecutive_bonus] if consecutive_successes >= CONSECUTIVE_BONUS_THRESHOLD
+          (confidence + delta).clamp(0.0, 1.0)
+        end
+
+        def decay(confidence, hours: 1)
+          (confidence * (DECAY_RATE**hours)).clamp(0.0, 1.0)
+        end
+
+        def autonomy_mode(confidence)
+          AUTONOMY_RANGES.find { |_mode, range| range.cover?(confidence) }&.first || :observe
+        end
+      end
+
+      @store = Concurrent::Hash.new
+      @dirty = false
+      @mutex = Mutex.new
+
+      module_function
+
+      # --- Confidence math delegation ---
+
+      def starting_score(origin)
+        if defined?(Legion::Extensions::Synapse::Helpers::Confidence)
+          Legion::Extensions::Synapse::Helpers::Confidence.starting_score(origin)
+        else
+          Math.starting_score(origin)
+        end
+      end
+
+      def adjust(confidence, event, consecutive_successes: 0)
+        if defined?(Legion::Extensions::Synapse::Helpers::Confidence)
+          Legion::Extensions::Synapse::Helpers::Confidence.adjust(confidence, event,
+                                                                  consecutive_successes: consecutive_successes)
+        else
+          Math.adjust(confidence, event, consecutive_successes: consecutive_successes)
+        end
+      end
+
+      def decay_confidence(confidence, hours: 1)
+        if defined?(Legion::Extensions::Synapse::Helpers::Confidence)
+          Legion::Extensions::Synapse::Helpers::Confidence.decay(confidence, hours: hours)
+        else
+          Math.decay(confidence, hours: hours)
+        end
+      end
+
+      def e_weight
+        if defined?(Legion::Extensions::Synapse::Helpers::Confidence)
+          Legion::Extensions::Synapse::Helpers::Confidence::E_WEIGHT
+        else
+          Math::E_WEIGHT
+        end
+      end
+
+      # --- Public API ---
+
+      def for(identity:, domain:)
+        key = store_key(identity, domain)
+        entry = @store[key]
+        return nil unless entry
+
+        apply_lazy_decay(entry)
+      end
+
+      def crystallize(identity:, domain:, directive:, evidence_trace_ids: [], origin: 'emergent')
+        key = store_key(identity, domain)
+        @mutex.synchronize do
+          return @store[key] if @store[key]
+
+          conf   = starting_score(origin.to_sym)
+          now    = Time.now.utc
+          entry  = {
+            id: SecureRandom.uuid,
+            identity: identity.to_s,
+            domain: domain.to_s,
+            origin: origin.to_s,
+            confidence: conf,
+            emotional_valence: 0.0,
+            emotional_intensity: 0.0,
+            consecutive_failures: 0,
+            consecutive_successes: 0,
+            directive: directive,
+            evidence_trace_ids: Array(evidence_trace_ids),
+            status: 'active',
+            last_applied_at: nil,
+            last_reinforced_at: now,
+            created_at: now
+          }
+          @store[key] = entry
+          @dirty = true
+          log.info("[gaia] synapse crystallized identity=#{identity} domain=#{domain} origin=#{origin} conf=#{conf}")
+          entry
+        end
+      end
+
+      def record_outcome(id:, outcome:, multiplier: 1.0)
+        @mutex.synchronize do
+          entry = find_by_id(id)
+          return { found: false } unless entry
+
+          conf = entry[:confidence]
+          base_event = outcome.to_sym
+          new_conf = adjust(conf, base_event, consecutive_successes: entry[:consecutive_successes])
+
+          # Apply multiplier to delta (scale the delta, not the raw confidence)
+          raw_delta = new_conf - conf
+          scaled_conf = (conf + (raw_delta * multiplier)).clamp(0.0, 1.0)
+
+          if base_event == :success
+            entry[:consecutive_successes] = entry[:consecutive_successes].to_i + 1
+            entry[:consecutive_failures]  = 0
+          elsif base_event == :failure
+            entry[:consecutive_failures]  = entry[:consecutive_failures].to_i + 1
+            entry[:consecutive_successes] = 0
+          end
+
+          entry[:confidence]          = scaled_conf
+          entry[:last_reinforced_at]  = Time.now.utc
+          @dirty = true
+
+          apply_pain(entry) if entry[:consecutive_failures].to_i >= 3
+
+          entry
+        end
+      end
+
+      def all_for(identity:)
+        prefix = "#{identity}:"
+        @store.select { |key, _| key.start_with?(prefix) }.values
+      end
+
+      def erase_partner!(identity:)
+        prefix = "#{identity}:"
+        keys = @store.keys.select { |key| key.start_with?(prefix) }
+        keys.each { |key| @store.delete(key) }
+        @mutex.synchronize { @dirty = true } unless keys.empty?
+        log.info("[gaia] BehavioralSynapse erased identity=#{identity} count=#{keys.size}")
+        keys.size
+      end
+
+      def store
+        @store
+      end
+
+      def reset!
+        @mutex.synchronize do
+          @store = Concurrent::Hash.new
+          @dirty = false
+        end
+      end
+
+      # --- TrackerPersistence support ---
+
+      def dirty?
+        @dirty == true
+      end
+
+      def mark_clean!
+        @dirty = false
+      end
+
+      def to_apollo_entries
+        @store.values.map do |entry|
+          identity = entry[:identity]
+          {
+            content: Legion::JSON.dump(entry),
+            tags: TO_APOLLO_TAGS + ["partner:#{identity}"],
+            confidence: entry[:confidence] || 0.3,
+            access_scope: 'local'
+          }
+        end
+      end
+
+      def from_apollo(store: nil)
+        return unless store
+
+        result = store.query(text: 'behavior', tags: TO_APOLLO_TAGS)
+        return unless result.is_a?(Hash) && result[:success]
+
+        count = 0
+        result[:results]&.each do |entry|
+          hydrate_apollo_entry(entry)
+          count += 1
+        rescue StandardError => e
+          log.debug("[gaia] BehavioralSynapse skipped unparseable Apollo entry: #{e.message}")
+        end
+        log.info("[gaia] BehavioralSynapse hydrated from Apollo count=#{count}")
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'gaia.behavioral_synapse.from_apollo')
+      end
+
+      private
+
+      def store_key(identity, domain)
+        "#{identity}:#{domain}"
+      end
+
+      def find_by_id(id)
+        @store.values.find { |entry| entry[:id] == id }
+      end
+
+      def apply_lazy_decay(entry)
+        return entry unless entry[:last_reinforced_at]
+
+        hours = (Time.now.utc - entry[:last_reinforced_at]) / 3600.0
+        intensity = entry[:emotional_intensity].to_f
+        effective_hours = hours / (1 + (intensity * e_weight))
+        return entry if effective_hours < 0.001
+
+        new_conf = decay_confidence(entry[:confidence], hours: effective_hours)
+        @mutex.synchronize do
+          entry[:confidence]         = new_conf
+          entry[:last_reinforced_at] = Time.now.utc
+          @dirty = true
+        end
+        entry
+      end
+
+      def apply_pain(entry)
+        entry[:status]                = 'dampened'
+        entry[:confidence]            = 0.29
+        entry[:consecutive_failures]  = 0
+        entry[:consecutive_successes] = 0
+        log.warn("[gaia] synapse pain id=#{entry[:id]} domain=#{entry[:domain]} identity=#{entry[:identity]}")
+
+        if defined?(Legion::Events) && Legion::Events.respond_to?(:emit)
+          Legion::Events.emit('gaia.behavior.reverted',
+                              id: entry[:id], identity: entry[:identity], domain: entry[:domain])
+        end
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'gaia.behavioral_synapse.apply_pain', id: entry[:id])
+      end
+
+      def hydrate_apollo_entry(raw_entry)
+        return unless raw_entry[:content].to_s.start_with?('{')
+
+        parsed = Legion::JSON.load(raw_entry[:content])
+        return unless parsed[:id] && parsed[:identity] && parsed[:domain]
+
+        key = store_key(parsed[:identity], parsed[:domain])
+        @mutex.synchronize do
+          @store[key] = {
+            id: parsed[:id],
+            identity: parsed[:identity].to_s,
+            domain: parsed[:domain].to_s,
+            origin: parsed[:origin].to_s,
+            confidence: parsed[:confidence].to_f,
+            emotional_valence: parsed[:emotional_valence].to_f,
+            emotional_intensity: parsed[:emotional_intensity].to_f,
+            consecutive_failures: parsed[:consecutive_failures].to_i,
+            consecutive_successes: parsed[:consecutive_successes].to_i,
+            directive: parsed[:directive],
+            evidence_trace_ids: Array(parsed[:evidence_trace_ids]),
+            status: parsed[:status].to_s,
+            last_applied_at: parsed[:last_applied_at],
+            last_reinforced_at: parse_time(parsed[:last_reinforced_at]),
+            created_at: parse_time(parsed[:created_at])
+          }
+        end
+      end
+
+      def parse_time(value)
+        return value if value.is_a?(Time)
+        return nil if value.nil?
+
+        Time.parse(value.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      module_function :store_key, :find_by_id, :apply_lazy_decay, :apply_pain, :hydrate_apollo_entry, :parse_time
+
+      # Wrapper class that satisfies TrackerPersistence interface
+      class Tracker
+        def dirty?
+          BehavioralSynapse.dirty?
+        end
+
+        def mark_clean!
+          BehavioralSynapse.mark_clean!
+        end
+
+        def to_apollo_entries
+          BehavioralSynapse.to_apollo_entries
+        end
+
+        def from_apollo(store: nil)
+          BehavioralSynapse.from_apollo(store: store)
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.59'
+    VERSION = '0.9.60'
   end
 end

--- a/spec/legion/gaia/behavioral_synapse_spec.rb
+++ b/spec/legion/gaia/behavioral_synapse_spec.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Gaia::BehavioralSynapse do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  # ---- Math module constants ----
+
+  describe 'Math constants' do
+    subject(:math) { described_class::Math }
+
+    it 'has correct STARTING_SCORES' do
+      expect(math::STARTING_SCORES).to eq(explicit: 0.7, emergent: 0.3, seeded: 0.5)
+    end
+
+    it 'has correct DECAY_RATE' do
+      expect(math::DECAY_RATE).to eq(0.998)
+    end
+
+    it 'has correct CONSECUTIVE_BONUS_THRESHOLD' do
+      expect(math::CONSECUTIVE_BONUS_THRESHOLD).to eq(50)
+    end
+
+    it 'has correct E_WEIGHT' do
+      expect(math::E_WEIGHT).to eq(3.0)
+    end
+
+    it 'covers full 0..1 range in AUTONOMY_RANGES' do
+      ranges = math::AUTONOMY_RANGES.values
+      expect(ranges.map(&:min).min).to eq(0.0)
+      expect(ranges.map(&:max).max).to eq(1.0)
+    end
+  end
+
+  # ---- starting_score ----
+
+  describe '.starting_score' do
+    it 'returns 0.7 for explicit' do
+      expect(described_class.starting_score(:explicit)).to eq(0.7)
+    end
+
+    it 'returns 0.3 for emergent' do
+      expect(described_class.starting_score(:emergent)).to eq(0.3)
+    end
+
+    it 'returns 0.5 for seeded' do
+      expect(described_class.starting_score(:seeded)).to eq(0.5)
+    end
+
+    it 'returns 0.3 for unknown origin' do
+      expect(described_class.starting_score(:unknown_origin)).to eq(0.3)
+    end
+  end
+
+  # ---- .for ----
+
+  describe '.for' do
+    it 'returns nil when no entry exists' do
+      expect(described_class.for(identity: 'alice', domain: 'feedback')).to be_nil
+    end
+
+    it 'returns the entry after crystallize' do
+      described_class.crystallize(identity: 'alice', domain: 'feedback', directive: 'be concise')
+      entry = described_class.for(identity: 'alice', domain: 'feedback')
+      expect(entry).to be_a(Hash)
+      expect(entry[:identity]).to eq('alice')
+    end
+  end
+
+  # ---- .crystallize ----
+
+  describe '.crystallize' do
+    it 'creates an entry at emergent starting confidence (0.3)' do
+      entry = described_class.crystallize(identity: 'alice', domain: 'tone', directive: 'friendly')
+      expect(entry[:confidence]).to eq(0.3)
+      expect(entry[:origin]).to eq('emergent')
+      expect(entry[:status]).to eq('active')
+    end
+
+    it 'is idempotent — returns same entry on second call' do
+      first  = described_class.crystallize(identity: 'alice', domain: 'tone', directive: 'friendly')
+      second = described_class.crystallize(identity: 'alice', domain: 'tone', directive: 'other')
+      expect(second[:id]).to eq(first[:id])
+      expect(second[:directive]).to eq('friendly')
+    end
+
+    it 'creates an explicit entry at 0.7 when origin is explicit' do
+      entry = described_class.crystallize(identity: 'bob', domain: 'length', directive: 'brief',
+                                          origin: 'explicit')
+      expect(entry[:confidence]).to be_within(0.001).of(0.7)
+      expect(entry[:origin]).to eq('explicit')
+    end
+
+    it 'stores evidence_trace_ids' do
+      entry = described_class.crystallize(identity: 'alice', domain: 'style', directive: 'bullets',
+                                          evidence_trace_ids: %w[trace-1 trace-2])
+      expect(entry[:evidence_trace_ids]).to eq(%w[trace-1 trace-2])
+    end
+
+    it 'assigns a UUID id' do
+      entry = described_class.crystallize(identity: 'alice', domain: 'style2', directive: 'bullets')
+      expect(entry[:id]).to match(/\A[0-9a-f-]{36}\z/)
+    end
+  end
+
+  # ---- .record_outcome ----
+
+  describe '.record_outcome' do
+    let!(:entry) { described_class.crystallize(identity: 'alice', domain: 'voice', directive: 'warm') }
+
+    it 'returns found: false for unknown id' do
+      result = described_class.record_outcome(id: 'no-such-id', outcome: :success)
+      expect(result[:found]).to eq(false)
+    end
+
+    it 'increases confidence on :success' do
+      before_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      described_class.record_outcome(id: entry[:id], outcome: :success)
+      after_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      expect(after_conf).to be > before_conf
+    end
+
+    it 'decreases confidence on :failure' do
+      before_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      described_class.record_outcome(id: entry[:id], outcome: :failure)
+      after_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      expect(after_conf).to be < before_conf
+    end
+
+    it 'success delta matches Math::ADJUSTMENTS[:success]' do
+      before_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      described_class.record_outcome(id: entry[:id], outcome: :success)
+      after_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      expect(after_conf - before_conf).to be_within(0.001).of(described_class::Math::ADJUSTMENTS[:success])
+    end
+
+    it 'failure delta matches Math::ADJUSTMENTS[:failure]' do
+      before_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      described_class.record_outcome(id: entry[:id], outcome: :failure)
+      after_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      expect(after_conf - before_conf).to be_within(0.001).of(described_class::Math::ADJUSTMENTS[:failure])
+    end
+
+    it 'scales delta by multiplier' do
+      before_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      described_class.record_outcome(id: entry[:id], outcome: :success, multiplier: 2.0)
+      after_conf = described_class.for(identity: 'alice', domain: 'voice')[:confidence]
+      expected_delta = described_class::Math::ADJUSTMENTS[:success] * 2.0
+      expect(after_conf - before_conf).to be_within(0.001).of(expected_delta)
+    end
+
+    it 'tracks consecutive successes' do
+      3.times { described_class.record_outcome(id: entry[:id], outcome: :success) }
+      refreshed = described_class.for(identity: 'alice', domain: 'voice')
+      expect(refreshed[:consecutive_successes]).to eq(3)
+      expect(refreshed[:consecutive_failures]).to eq(0)
+    end
+
+    it 'resets consecutive successes on failure' do
+      2.times { described_class.record_outcome(id: entry[:id], outcome: :success) }
+      described_class.record_outcome(id: entry[:id], outcome: :failure)
+      refreshed = described_class.for(identity: 'alice', domain: 'voice')
+      expect(refreshed[:consecutive_successes]).to eq(0)
+      expect(refreshed[:consecutive_failures]).to eq(1)
+    end
+
+    context 'pain: 3 consecutive failures' do
+      before do
+        # Set confidence high so dampening to 0.29 is observable
+        entry_key = 'alice:voice'
+        described_class.store[entry_key][:confidence] = 0.8
+      end
+
+      it 'sets status to dampened' do
+        3.times { described_class.record_outcome(id: entry[:id], outcome: :failure) }
+        refreshed = described_class.for(identity: 'alice', domain: 'voice')
+        expect(refreshed[:status]).to eq('dampened')
+      end
+
+      it 'floors confidence to 0.29' do
+        3.times { described_class.record_outcome(id: entry[:id], outcome: :failure) }
+        refreshed = described_class.for(identity: 'alice', domain: 'voice')
+        expect(refreshed[:confidence]).to eq(0.29)
+      end
+
+      it 'resets consecutive counters' do
+        3.times { described_class.record_outcome(id: entry[:id], outcome: :failure) }
+        refreshed = described_class.for(identity: 'alice', domain: 'voice')
+        expect(refreshed[:consecutive_failures]).to eq(0)
+        expect(refreshed[:consecutive_successes]).to eq(0)
+      end
+
+      it 'emits gaia.behavior.reverted if Legion::Events is defined' do
+        events_stub = Module.new
+        allow(events_stub).to receive(:emit)
+        stub_const('Legion::Events', events_stub)
+        3.times { described_class.record_outcome(id: entry[:id], outcome: :failure) }
+        expect(events_stub).to have_received(:emit).with('gaia.behavior.reverted', hash_including(id: entry[:id]))
+      end
+    end
+  end
+
+  # ---- lazy decay ----
+
+  describe '.for with lazy decay' do
+    it 'decays confidence after idle hours' do
+      entry = described_class.crystallize(identity: 'alice', domain: 'decay_test', directive: 'test')
+      original_conf = entry[:confidence]
+
+      # Fake the last_reinforced_at to be 24 hours ago
+      key = 'alice:decay_test'
+      described_class.store[key][:last_reinforced_at] = Time.now.utc - (24 * 3600)
+
+      refreshed = described_class.for(identity: 'alice', domain: 'decay_test')
+      expect(refreshed[:confidence]).to be < original_conf
+    end
+
+    it 'resists decay more at high emotional intensity' do
+      # Two synapses: same age, but different intensities
+      described_class.crystallize(identity: 'alice', domain: 'low_intensity', directive: 'low')
+      described_class.crystallize(identity: 'alice', domain: 'high_intensity', directive: 'high')
+
+      past = Time.now.utc - (48 * 3600)
+      described_class.store['alice:low_intensity'][:last_reinforced_at]    = past
+      described_class.store['alice:low_intensity'][:emotional_intensity]   = 0.0
+      described_class.store['alice:high_intensity'][:last_reinforced_at]   = past
+      described_class.store['alice:high_intensity'][:emotional_intensity]  = 1.0
+
+      low  = described_class.for(identity: 'alice', domain: 'low_intensity')[:confidence]
+      high = described_class.for(identity: 'alice', domain: 'high_intensity')[:confidence]
+
+      expect(high).to be > low
+    end
+  end
+
+  # ---- .all_for ----
+
+  describe '.all_for' do
+    it 'returns only entries for the requested identity' do
+      described_class.crystallize(identity: 'alice', domain: 'a', directive: 'd1')
+      described_class.crystallize(identity: 'alice', domain: 'b', directive: 'd2')
+      described_class.crystallize(identity: 'bob',   domain: 'a', directive: 'd3')
+
+      result = described_class.all_for(identity: 'alice')
+      expect(result.size).to eq(2)
+      expect(result.map { |e| e[:identity] }.uniq).to eq(['alice'])
+    end
+
+    it 'returns empty array when no entries exist' do
+      expect(described_class.all_for(identity: 'nobody')).to eq([])
+    end
+  end
+
+  # ---- .erase_partner! ----
+
+  describe '.erase_partner!' do
+    it 'removes all entries for the identity' do
+      described_class.crystallize(identity: 'alice', domain: 'a', directive: 'd1')
+      described_class.crystallize(identity: 'alice', domain: 'b', directive: 'd2')
+      described_class.crystallize(identity: 'bob',   domain: 'a', directive: 'd3')
+
+      count = described_class.erase_partner!(identity: 'alice')
+      expect(count).to eq(2)
+      expect(described_class.all_for(identity: 'alice')).to be_empty
+    end
+
+    it 'leaves other identities untouched' do
+      described_class.crystallize(identity: 'alice', domain: 'a', directive: 'd1')
+      described_class.crystallize(identity: 'bob',   domain: 'a', directive: 'd2')
+
+      described_class.erase_partner!(identity: 'alice')
+      expect(described_class.all_for(identity: 'bob').size).to eq(1)
+    end
+
+    it 'returns 0 when no entries exist' do
+      expect(described_class.erase_partner!(identity: 'ghost')).to eq(0)
+    end
+  end
+
+  # ---- Tracker persistence ----
+
+  describe 'Tracker' do
+    subject(:tracker) { described_class::Tracker.new }
+
+    before do
+      described_class.crystallize(identity: 'alice', domain: 'tone', directive: 'friendly')
+      described_class.mark_clean!
+    end
+
+    it 'is clean after mark_clean!' do
+      expect(tracker.dirty?).to be false
+    end
+
+    it 'is dirty after crystallize' do
+      described_class.crystallize(identity: 'bob', domain: 'style', directive: 'brief')
+      expect(tracker.dirty?).to be true
+    end
+
+    it 'is clean again after mark_clean!' do
+      described_class.crystallize(identity: 'bob', domain: 'style', directive: 'brief')
+      tracker.mark_clean!
+      expect(tracker.dirty?).to be false
+    end
+
+    describe '#to_apollo_entries' do
+      it 'returns one entry per synapse' do
+        described_class.crystallize(identity: 'charlie', domain: 'x', directive: 'd')
+        entries = tracker.to_apollo_entries
+        expect(entries.size).to be >= 2
+      end
+
+      it 'each entry has content, tags, confidence, access_scope' do
+        entry = tracker.to_apollo_entries.first
+        expect(entry).to include(:content, :tags, :confidence, :access_scope)
+      end
+
+      it 'tags include self-knowledge and behavior' do
+        entry = tracker.to_apollo_entries.first
+        expect(entry[:tags]).to include('self-knowledge', 'behavior')
+      end
+
+      it 'tags include partner identity tag' do
+        entry = tracker.to_apollo_entries.find { |e| e[:tags].any? { |t| t.start_with?('partner:') } }
+        expect(entry).not_to be_nil
+      end
+    end
+
+    describe '#from_apollo' do
+      it 'hydrates entries from apollo store' do
+        # Build a store with a canned entry
+        synapse_data = {
+          id: 'test-uuid-1234-5678-9abc',
+          identity: 'hydrated_user',
+          domain: 'hydrated_domain',
+          origin: 'emergent',
+          confidence: 0.45,
+          emotional_valence: 0.1,
+          emotional_intensity: 0.2,
+          consecutive_failures: 0,
+          consecutive_successes: 2,
+          directive: 'be helpful',
+          evidence_trace_ids: [],
+          status: 'active',
+          last_applied_at: nil,
+          last_reinforced_at: Time.now.utc.iso8601,
+          created_at: Time.now.utc.iso8601
+        }
+
+        mock_store = instance_double('ApolloLocal')
+        allow(mock_store).to receive(:query).and_return({
+                                                          success: true,
+                                                          results: [{ content: Legion::JSON.dump(synapse_data) }]
+                                                        })
+
+        described_class.reset!
+        tracker.from_apollo(store: mock_store)
+
+        entry = described_class.for(identity: 'hydrated_user', domain: 'hydrated_domain')
+        expect(entry).not_to be_nil
+        expect(entry[:confidence]).to be_within(0.001).of(0.45)
+        expect(entry[:origin]).to eq('emergent')
+      end
+
+      it 'does nothing when store is nil' do
+        expect { tracker.from_apollo(store: nil) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add BehavioralSynapse store with vendored Confidence math (lifecycle: create, decay, grade, pain, crystallize)
- Add `record_response_applied` attribution facade for legion-llm's final-delivery hook
- Wire grading path: evaluate_calibration maps reaction_score to synapse confidence adjustments
- TrackerPersistence integration for Apollo local flush/hydrate

## Test plan
- [ ] `bundle exec rspec` passes (0 failures)
- [ ] `bundle exec rubocop` passes (0 offenses)
- [ ] BehavioralSynapse lifecycle specs cover: starting scores, adjust, decay, pain, crystallize, erase
- [ ] Attribution and grading path specs verify end-to-end flow

Closes #38