### PR TITLE
feat(loop): partner model composition — earned working-memory slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.61] - 2026-07-16
+### Added
+- H4: `PartnerModel` — 7-slot working-memory competition (§12.4); only filter/transform/autonomous tier synapses compete, observe-tier excluded; unified ranking across synapses, traces, and preferences by `strength × (1 + emotional_intensity)`; `observe_mode_entries` transparency surface
+- Wire `update_from_observation` on `PreferenceProfile` in `observe_interlocutor` (soft-guarded on lex-mesh)
+- Correction detection: explicit negative feedback after applied behavioral response → correction trace via lex-agentic-memory
+- Crystallization path: N corroborating corrections (default threshold 3) per (identity, domain) → `BehavioralSynapse.crystallize` with `origin: 'emergent'`
+
 ## [0.9.60] - 2026-07-16
 ### Added
 - H2: BehavioralSynapse store with vendored Confidence math (lifecycle: crystallize, lazy decay with intensity resistance, grade via record_outcome, pain at 3 consecutive failures → dampened + event emission)

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -33,6 +33,7 @@ require 'legion/gaia/offline_handler'
 require 'legion/gaia/proactive_dispatcher'
 require 'legion/gaia/bond_registry'
 require 'legion/gaia/behavioral_synapse'
+require 'legion/gaia/partner_model'
 require 'legion/gaia/tracker_persistence'
 require 'legion/gaia/router'
 
@@ -120,6 +121,7 @@ module Legion
         @last_valences = nil
         @last_response_at = nil
         @last_applied = nil
+        @correction_counts = nil
         @tick_history = nil
         @tick_count = nil
         @started_at = nil
@@ -401,6 +403,7 @@ module Legion
         @registry.discover
         boot_channels
         boot_agent_bridge
+        @correction_counts = Concurrent::Hash.new(0)
         register_behavioral_synapse_tracker
         hydrate_from_apollo_local
         register_provisional_partner_prior
@@ -583,11 +586,7 @@ module Legion
           bootstrap.record_observation
         end
 
-        # The gate: only partner-level identities get deep learning
-        if BondRegistry.partner?(identity_str)
-          record_interaction_trace(observation)
-          evaluate_calibration(observation)
-        end
+        run_partner_deep_learning(identity_str, observation) if BondRegistry.partner?(identity_str)
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.observe_interlocutor', identity: identity)
       end
@@ -705,6 +704,91 @@ module Legion
         @last_applied = nil
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'gaia.grade_behavioral_synapses')
+      end
+
+      def run_partner_deep_learning(identity_str, observation)
+        record_interaction_trace(observation)
+        evaluate_calibration(observation)
+        update_preference_profile(identity_str, observation)
+        detect_and_record_correction(identity_str, observation)
+      end
+
+      def update_preference_profile(identity_str, observation)
+        return unless defined?(Legion::Extensions::Mesh::Helpers::PreferenceProfile)
+
+        Legion::Extensions::Mesh::Helpers::PreferenceProfile.update_from_observation(
+          owner_id: identity_str, signals: observation
+        )
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'gaia.update_preference_profile', identity: identity_str)
+      end
+
+      def detect_and_record_correction(identity_str, observation)
+        return unless defined?(Legion::Extensions::Agentic::Social::Calibration::Runners::Calibration)
+        return unless @last_applied&.dig(:behavioral_synapse_ids)&.any?
+
+        ensure_calibration_runner
+        feedback_result = @calibration_runner.detect_explicit_feedback(content: observation[:content].to_s)
+        return unless feedback_result[:feedback] == :negative
+
+        record_correction_trace(identity: identity_str, applied: @last_applied, observation: observation)
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'gaia.detect_and_record_correction', identity: identity_str)
+      end
+
+      def record_correction_trace(identity:, applied:, observation:)
+        return unless defined?(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces)
+
+        runner = Object.new
+        runner.extend(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces)
+        runner.store_trace(
+          type: :correction,
+          content_payload: {
+            correction_type: :explicit_negative_feedback,
+            applied_synapse_ids: Array(applied[:behavioral_synapse_ids]),
+            channel: observation[:channel],
+            content_type: observation[:content_type]
+          },
+          domain_tags: ['correction', "partner:#{identity}"],
+          origin: :direct_experience,
+          emotional_valence: -0.5,
+          emotional_intensity: 0.6,
+          confidence: 0.9
+        ).tap do |trace_result|
+          log.info("[gaia] correction trace identity=#{identity} " \
+                   "trace=#{trace_result[:trace_id].to_s[0, 8]} " \
+                   "synapse_ids=#{Array(applied[:behavioral_synapse_ids]).size}")
+          check_crystallization(identity: identity, applied: applied, trace_id: trace_result[:trace_id])
+        end
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'gaia.record_correction_trace', identity: identity)
+      end
+
+      def check_crystallization(identity:, applied:, trace_id:)
+        domain = applied[:domain].to_s
+        return if domain.empty?
+
+        threshold = settings&.dig(:partner_model, :crystallize_threshold) || 3
+        @correction_counts ||= Concurrent::Hash.new(0)
+        key = "#{identity}:#{domain}"
+        @correction_counts[key] += 1
+        count = @correction_counts[key]
+
+        return unless count >= threshold
+
+        synapse_ids = Array(applied[:behavioral_synapse_ids])
+        BehavioralSynapse.crystallize(
+          identity: identity,
+          domain: domain,
+          directive: applied[:directive].to_s,
+          evidence_trace_ids: synapse_ids + [trace_id.to_s],
+          origin: 'emergent'
+        )
+        @correction_counts[key] = 0
+        log.info("[gaia] crystallization triggered identity=#{identity} domain=#{domain} " \
+                 "corrections=#{count} threshold=#{threshold}")
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'gaia.check_crystallization', identity: identity)
       end
 
       def fetch_imprint_multiplier

--- a/lib/legion/gaia/partner_model.rb
+++ b/lib/legion/gaia/partner_model.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Legion
+  module Gaia
+    module PartnerModel
+      # Working-memory slot competition (§12.4).
+      # Only filter/transform/autonomous tier synapses compete — observe-tier synapses are
+      # tracked separately via observe_mode_entries and never consume working-memory slots.
+      MAX_WORKING_MEMORY_SLOTS = 7
+
+      # Source-confidence defaults for preference candidates.
+      PREFERENCE_SOURCE_CONFIDENCE = {
+        explicit: 1.0,
+        preference_learning: 0.75,
+        llm_inference: 0.65,
+        observation: 0.55
+      }.freeze
+
+      module_function
+
+      # Build the working-memory slot array for this identity.
+      #
+      # @param identity [String, Symbol] the partner identity key
+      # @param synapses [Array, nil] BehavioralSynapse entries; fetched from store if nil
+      # @param traces   [Array, nil] episodic/semantic trace hashes from lex-agentic-memory
+      # @param preferences [Array, nil] PreferenceProfile directives with :source and :content
+      # @return [Array<Hash>] at most MAX_WORKING_MEMORY_SLOTS slot hashes, sorted by score desc
+      def build(identity:, synapses: nil, traces: nil, preferences: nil)
+        identity_str = identity.to_s
+        candidates = []
+        candidates.concat(synapse_candidates(identity: identity_str, synapses: synapses))
+        candidates.concat(trace_candidates(traces))
+        candidates.concat(preference_candidates(preferences))
+
+        max_slots = Legion::Gaia.settings&.dig(:partner_model, :max_slots) || MAX_WORKING_MEMORY_SLOTS
+
+        candidates
+          .sort_by { |c| -slot_score(c) }
+          .first(max_slots)
+          .map { |c| c.slice(:type, :domain, :content, :strength, :source_id, :autonomy_mode) }
+      end
+
+      # Returns observe-tier synapses for this identity (transparency surface — not in working memory).
+      #
+      # @param identity [String, Symbol]
+      # @return [Array<Hash>]
+      def observe_mode_entries(identity:)
+        identity_str = identity.to_s
+        all = Legion::Gaia::BehavioralSynapse.all_for(identity: identity_str)
+        all.select { |entry| autonomy_tier(entry[:confidence]) == :observe }
+           .map do |entry|
+             {
+               type: :synapse,
+               domain: entry[:domain],
+               content: entry[:directive],
+               strength: entry[:confidence],
+               source_id: entry[:id],
+               autonomy_mode: :observe
+             }
+           end
+      end
+
+      # --- private helpers ---
+
+      def synapse_candidates(identity:, synapses:)
+        entries = synapses || Legion::Gaia::BehavioralSynapse.all_for(identity: identity)
+        entries.filter_map do |entry|
+          tier = autonomy_tier(entry[:confidence])
+          next unless %i[filter transform autonomous].include?(tier)
+
+          {
+            type: :synapse,
+            domain: entry[:domain],
+            content: entry[:directive],
+            strength: entry[:confidence].to_f,
+            emotional_intensity: entry[:emotional_intensity].to_f,
+            source_id: entry[:id],
+            autonomy_mode: tier
+          }
+        end
+      end
+
+      def trace_candidates(traces)
+        return [] unless traces.is_a?(Array)
+
+        traces.map do |trace|
+          strength = (trace[:strength] || trace[:confidence]).to_f
+          intensity = (trace[:emotional_intensity] || 0.5).to_f
+          {
+            type: :trace,
+            domain: Array(trace[:domain_tags]).first.to_s,
+            content: trace[:content_payload],
+            strength: strength,
+            emotional_intensity: intensity,
+            source_id: trace[:trace_id],
+            autonomy_mode: nil
+          }
+        end
+      end
+
+      def preference_candidates(preferences)
+        return [] unless preferences.is_a?(Array)
+
+        preferences.map do |pref|
+          source_key = pref[:source].to_s.to_sym
+          strength = PREFERENCE_SOURCE_CONFIDENCE.fetch(source_key, 0.55)
+          {
+            type: :preference,
+            domain: pref[:domain].to_s,
+            content: pref[:content] || pref[:directive],
+            strength: strength,
+            emotional_intensity: 0.3,
+            source_id: pref[:id],
+            autonomy_mode: nil
+          }
+        end
+      end
+
+      def slot_score(candidate)
+        strength  = candidate[:strength].to_f
+        intensity = candidate[:emotional_intensity].to_f
+        strength * (1.0 + intensity)
+      end
+
+      def autonomy_tier(confidence)
+        Legion::Gaia::BehavioralSynapse::Math.autonomy_mode(confidence.to_f)
+      end
+
+      module_function :synapse_candidates, :trace_candidates, :preference_candidates,
+                      :slot_score, :autonomy_tier
+    end
+  end
+end

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.60'
+    VERSION = '0.9.61'
   end
 end

--- a/spec/legion/gaia/partner_model_spec.rb
+++ b/spec/legion/gaia/partner_model_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Gaia::PartnerModel do
+  let(:identity) { 'test-partner' }
+
+  def make_synapse(domain:, confidence:, emotional_intensity: 0.0, directive: 'do something', id: nil)
+    {
+      id: id || SecureRandom.uuid,
+      identity: identity,
+      domain: domain,
+      confidence: confidence,
+      emotional_intensity: emotional_intensity,
+      directive: directive,
+      origin: 'explicit',
+      status: 'active'
+    }
+  end
+
+  def make_trace(strength:, emotional_intensity: 0.5, domain_tags: ['partner_interaction'], trace_id: nil,
+                 content_payload: {})
+    {
+      trace_id: trace_id || SecureRandom.uuid,
+      strength: strength,
+      emotional_intensity: emotional_intensity,
+      domain_tags: domain_tags,
+      content_payload: content_payload
+    }
+  end
+
+  def make_preference(source:, domain: 'style', content: 'be concise', id: nil)
+    { id: id || SecureRandom.uuid, source: source, domain: domain, content: content }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Slot count basics
+  # ---------------------------------------------------------------------------
+
+  describe '.build — slot count' do
+    context 'with 7 transform-tier synapses (confidence 0.7)' do
+      let(:synapses) do
+        7.times.map { |i| make_synapse(domain: "domain_#{i}", confidence: 0.7) }
+      end
+
+      it 'returns all 7 slots' do
+        result = described_class.build(identity: identity, synapses: synapses)
+        expect(result.size).to eq(7)
+      end
+    end
+
+    context 'with 10 transform-tier synapses' do
+      let(:synapses) do
+        10.times.map { |i| make_synapse(domain: "domain_#{i}", confidence: 0.7) }
+      end
+
+      it 'returns only 7 slots (hard cap)' do
+        result = described_class.build(identity: identity, synapses: synapses)
+        expect(result.size).to eq(7)
+      end
+    end
+
+    context 'with 7 observe-tier + 3 transform-tier synapses' do
+      let(:synapses) do
+        observe = 7.times.map { |i| make_synapse(domain: "obs_#{i}", confidence: 0.1) }
+        transform = 3.times.map { |i| make_synapse(domain: "xform_#{i}", confidence: 0.7) }
+        observe + transform
+      end
+
+      it 'returns only 3 slots (observe excluded)' do
+        result = described_class.build(identity: identity, synapses: synapses)
+        expect(result.size).to eq(3)
+      end
+
+      it 'all returned slots are not observe-mode' do
+        result = described_class.build(identity: identity, synapses: synapses)
+        modes = result.map { |s| s[:autonomy_mode] }
+        expect(modes).not_to include(:observe)
+      end
+    end
+
+    context 'with zero transform/filter/autonomous synapses (only observe)' do
+      let(:synapses) do
+        5.times.map { |i| make_synapse(domain: "obs_#{i}", confidence: 0.1) }
+      end
+
+      it 'returns empty array' do
+        result = described_class.build(identity: identity, synapses: synapses)
+        expect(result).to be_empty
+      end
+    end
+
+    context 'with no synapses, traces, or preferences' do
+      it 'returns empty array' do
+        result = described_class.build(identity: identity, synapses: [], traces: [], preferences: [])
+        expect(result).to be_empty
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Mixed-type competition
+  # ---------------------------------------------------------------------------
+
+  describe '.build — mixed-type competition' do
+    it 'combines synapses, traces, and preferences in one ranking' do
+      synapses    = [make_synapse(domain: 'behavior', confidence: 0.75)]
+      traces      = [make_trace(strength: 0.8, domain_tags: ['correction'])]
+      preferences = [make_preference(source: 'explicit', domain: 'style')]
+
+      result = described_class.build(identity: identity, synapses: synapses,
+                                     traces: traces, preferences: preferences)
+      types = result.map { |s| s[:type] }
+      expect(types).to include(:synapse)
+      expect(types).to include(:trace)
+      expect(types).to include(:preference)
+    end
+
+    it 'ranks all candidates by score (strength * (1 + emotional_intensity)) descending' do
+      # high-intensity trace should outrank a lower-scored synapse
+      low_synapse  = make_synapse(domain: 'low',  confidence: 0.65, emotional_intensity: 0.0)
+      high_trace   = make_trace(strength: 0.65, emotional_intensity: 0.9, domain_tags: ['t'])
+
+      result = described_class.build(identity: identity, synapses: [low_synapse], traces: [high_trace])
+      expect(result.first[:type]).to eq(:trace)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scoring: higher emotional intensity boosts ranking
+  # ---------------------------------------------------------------------------
+
+  describe '.build — scoring' do
+    it 'a higher-intensity synapse ranks above an equal-strength lower-intensity one' do
+      low_intensity  = make_synapse(domain: 'low',  confidence: 0.72, emotional_intensity: 0.1,
+                                    id: 'aaa', directive: 'low')
+      high_intensity = make_synapse(domain: 'high', confidence: 0.72, emotional_intensity: 0.9,
+                                    id: 'bbb', directive: 'high')
+
+      result = described_class.build(identity: identity, synapses: [low_intensity, high_intensity])
+      expect(result.first[:source_id]).to eq('bbb')
+    end
+
+    it 'when 10 candidates exist, top 7 by score are selected' do
+      synapses = 10.times.map do |i|
+        # give each a distinct confidence so scores are ordered
+        make_synapse(domain: "d#{i}", confidence: 0.65 + (i * 0.003))
+      end
+
+      result = described_class.build(identity: identity, synapses: synapses)
+      domains = result.map { |s| s[:domain] }
+      # top 7 by score = indices 3..9 (highest confidence)
+      expect(domains).to include('d9', 'd8', 'd7', 'd6', 'd5', 'd4', 'd3')
+      expect(domains).not_to include('d0', 'd1', 'd2')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Slot shape
+  # ---------------------------------------------------------------------------
+
+  describe '.build — slot structure' do
+    let(:synapse) { make_synapse(domain: 'verbosity', confidence: 0.7, directive: 'be brief') }
+
+    it 'returns hashes with required keys' do
+      result = described_class.build(identity: identity, synapses: [synapse])
+      slot = result.first
+      expect(slot.keys).to match_array(%i[type domain content strength source_id autonomy_mode])
+    end
+
+    it 'sets autonomy_mode on synapse slots' do
+      result = described_class.build(identity: identity, synapses: [synapse])
+      expect(result.first[:autonomy_mode]).to eq(:transform)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # observe_mode_entries
+  # ---------------------------------------------------------------------------
+
+  describe '.observe_mode_entries' do
+    before { Legion::Gaia::BehavioralSynapse.reset! }
+    after  { Legion::Gaia::BehavioralSynapse.reset! }
+
+    context 'when observe-tier synapses exist for identity' do
+      before do
+        Legion::Gaia::BehavioralSynapse.crystallize(
+          identity: identity, domain: 'tone', directive: 'be casual', origin: 'explicit'
+        )
+        # force to observe tier by manually downgrading confidence
+        entry = Legion::Gaia::BehavioralSynapse.for(identity: identity, domain: 'tone')
+        entry[:confidence] = 0.1 if entry
+      end
+
+      it 'returns only observe-tier entries' do
+        # pass observe-tier synapses directly (store may differ due to crystallize starting score)
+        observe_synapse = make_synapse(domain: 'quiet', confidence: 0.1)
+        transform_synapse = make_synapse(domain: 'active', confidence: 0.72)
+
+        allow(Legion::Gaia::BehavioralSynapse).to receive(:all_for).with(identity: identity)
+                                                                   .and_return([observe_synapse, transform_synapse])
+
+        result = described_class.observe_mode_entries(identity: identity)
+        expect(result.size).to eq(1)
+        expect(result.first[:autonomy_mode]).to eq(:observe)
+        expect(result.first[:domain]).to eq('quiet')
+      end
+    end
+
+    context 'when no synapses exist for identity' do
+      before do
+        allow(Legion::Gaia::BehavioralSynapse).to receive(:all_for).with(identity: identity).and_return([])
+      end
+
+      it 'returns empty array' do
+        expect(described_class.observe_mode_entries(identity: identity)).to be_empty
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # MAX_WORKING_MEMORY_SLOTS setting override
+  # ---------------------------------------------------------------------------
+
+  describe 'MAX_WORKING_MEMORY_SLOTS' do
+    it 'is 7 by default' do
+      expect(described_class::MAX_WORKING_MEMORY_SLOTS).to eq(7)
+    end
+  end
+
+  describe '.build — respects settings max_slots override' do
+    let(:synapses) do
+      5.times.map { |i| make_synapse(domain: "d#{i}", confidence: 0.75) }
+    end
+
+    it 'caps at settings max_slots when set to 3' do
+      allow(Legion::Gaia).to receive(:settings).and_return({ partner_model: { max_slots: 3 } })
+      result = described_class.build(identity: identity, synapses: synapses)
+      expect(result.size).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add PartnerModel with 7-slot working-memory competition (§12.4)
- Only filter/transform/autonomous tier synapses compete for slots (observe excluded)
- Wire `update_from_observation` in observe_interlocutor (soft-guarded on lex-mesh)
- Add correction detection: negative feedback after applied response → correction trace
- Add crystallization path: N corroborating corrections → emergent synapse at 0.3

## Test plan
- [ ] `bundle exec rspec` passes (0 failures)
- [ ] `bundle exec rubocop` passes (0 offenses)
- [ ] PartnerModel specs: slot competition, observe exclusion, mixed-type ranking
- [ ] Correction detection and crystallization threshold specs

Closes #40