### PR TITLE
fix(h8-prep): add erase_partner! to BondRegistry + attribution erasure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.62] - 2026-07-22
+### Added
+- H8 prep: `BondRegistry.erase_partner!(identity:)` — thread-safe deletion of a single bond entry; marks registry dirty; emits `gaia.bond.erased` event if `Legion::Events` is defined; idempotent (no raise on missing identity)
+- H8 prep: `Gaia.erase_attribution!(identity:)` — erases Apollo Local attribution records tagged `self-knowledge/attribution/partner:<identity>` via `store.delete_by_tags`; includes TODO for `legion-apollo` to implement `delete_by_tags(tags:)`, gracefully no-ops until available
+
 ## [0.9.61] - 2026-07-16
 ### Added
 - H4: `PartnerModel` — 7-slot working-memory competition (§12.4); only filter/transform/autonomous tier synapses compete, observe-tier excluded; unified ranking across synapses, traces, and preferences by `strength × (1 + emotional_intensity)`; `observe_mode_entries` transparency surface

--- a/lib/legion/gaia.rb
+++ b/lib/legion/gaia.rb
@@ -246,6 +246,31 @@ module Legion
         end
       end
 
+      def erase_attribution!(identity:)
+        store = apollo_local_store
+        unless store
+          log.info("[gaia] erase_attribution! skipped identity=#{identity} reason=no_apollo_local")
+          return { erased: false, identity: identity, count: 0, reason: :no_apollo_local }
+        end
+
+        tags = %w[self-knowledge attribution] + ["partner:#{identity}"]
+        # TODO: legion-apollo needs delete_by_tags(tags:) — using query_by_tags + individual deletes once available
+        # Until then: store.delete_by_tags is the target API; this no-ops with count=0 until implemented
+        count = 0
+        if store.respond_to?(:delete_by_tags)
+          result = store.delete_by_tags(tags: tags)
+          count = result[:count].to_i if result.is_a?(Hash)
+        else
+          log.info("[gaia] erase_attribution! identity=#{identity} " \
+                   'reason=delete_by_tags_not_available count=0')
+        end
+        log.info("[gaia] erase_attribution! identity=#{identity} count=#{count}")
+        { erased: true, identity: identity, count: count }
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'gaia.erase_attribution', identity: identity)
+        { erased: false, identity: identity, count: 0 }
+      end
+
       def record_advisory_meta(advisory_id:, advisory_types:)
         return unless started?
 

--- a/lib/legion/gaia/bond_registry.rb
+++ b/lib/legion/gaia/bond_registry.rb
@@ -249,6 +249,19 @@ module Legion
         handle_exception(e, level: :warn, operation: 'gaia.bond_registry.hydrate_from_apollo')
       end
 
+      def erase_partner!(identity:)
+        erased = false
+        @mutex.synchronize do
+          erased = @bonds.delete(identity.to_s)
+          @dirty = true if erased
+        end
+        log.info("[gaia] bond erased identity=#{identity}") if erased
+        if defined?(Legion::Events) && Legion::Events.respond_to?(:emit)
+          Legion::Events.emit('gaia.bond.erased', identity: identity)
+        end
+        { erased: !erased.nil?, identity: identity }
+      end
+
       def reset!
         @mutex.synchronize do
           @bonds = Concurrent::Hash.new

--- a/lib/legion/gaia/version.rb
+++ b/lib/legion/gaia/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Gaia
-    VERSION = '0.9.61'
+    VERSION = '0.9.62'
   end
 end

--- a/spec/legion/gaia/bond_registry_spec.rb
+++ b/spec/legion/gaia/bond_registry_spec.rb
@@ -417,6 +417,61 @@ RSpec.describe Legion::Gaia::BondRegistry do
     end
   end
 
+  describe '.erase_partner!' do
+    it 'removes the target identity and leaves others untouched' do
+      described_class.register('X', bond: :partner, strength: 0.7)
+      described_class.register('Y', bond: :known, strength: 0.5)
+      described_class.erase_partner!(identity: 'X')
+      expect(described_class.bond('X')).to eq(:unknown)
+      expect(described_class.bond('Y')).to eq(:known)
+    end
+
+    it 'returns erased: true for existing identity' do
+      described_class.register('X', bond: :partner, strength: 0.7)
+      result = described_class.erase_partner!(identity: 'X')
+      expect(result).to eq({ erased: true, identity: 'X' })
+    end
+
+    it 'makes bond(:X) return :unknown after erasure' do
+      described_class.register('X', bond: :partner)
+      described_class.erase_partner!(identity: 'X')
+      expect(described_class.bond('X')).to eq(:unknown)
+    end
+
+    it 'makes partner?(:X) return false after erasure' do
+      described_class.register('X', bond: :partner, strength: 0.9)
+      described_class.erase_partner!(identity: 'X')
+      expect(described_class.partner?('X')).to be false
+    end
+
+    it 'marks the registry dirty after erasure' do
+      described_class.register('X', bond: :partner)
+      described_class.mark_clean!
+      described_class.erase_partner!(identity: 'X')
+      expect(described_class.dirty?).to be true
+    end
+
+    it 'is idempotent — erasing a non-existent identity does not raise' do
+      expect { described_class.erase_partner!(identity: 'ghost') }.not_to raise_error
+    end
+
+    it 'returns erased: false for non-existent identity' do
+      result = described_class.erase_partner!(identity: 'ghost')
+      expect(result).to eq({ erased: false, identity: 'ghost' })
+    end
+
+    context 'when Legion::Events is defined' do
+      it 'emits gaia.bond.erased event' do
+        described_class.register('X', bond: :partner, strength: 0.7)
+        events_stub = double('Legion::Events')
+        stub_const('Legion::Events', events_stub)
+        allow(events_stub).to receive(:respond_to?).with(:emit).and_return(true)
+        expect(events_stub).to receive(:emit).with('gaia.bond.erased', identity: 'X')
+        described_class.erase_partner!(identity: 'X')
+      end
+    end
+  end
+
   describe '.reset!' do
     it 'clears bonds and dirty flag' do
       described_class.register('test-id', bond: :partner, strength: 0.7)

--- a/spec/legion/gaia_spec.rb
+++ b/spec/legion/gaia_spec.rb
@@ -727,6 +727,52 @@ RSpec.describe Legion::Gaia do
     end
   end
 
+  describe '.erase_attribution!' do
+    context 'when Apollo Local is not available' do
+      it 'returns erased: false with reason :no_apollo_local' do
+        result = described_class.erase_attribution!(identity: 'X')
+        expect(result).to include(erased: false, identity: 'X', count: 0, reason: :no_apollo_local)
+      end
+    end
+
+    context 'when Apollo Local is available but has no delete_by_tags' do
+      let(:mock_store) do
+        double('ApolloLocal', started?: true).tap do |s|
+          allow(s).to receive(:respond_to?).with(:delete_by_tags).and_return(false)
+        end
+      end
+
+      before do
+        stub_const('Legion::Apollo::Local', mock_store)
+      end
+
+      it 'returns erased: true with count: 0' do
+        result = described_class.erase_attribution!(identity: 'X')
+        expect(result).to include(erased: true, identity: 'X', count: 0)
+      end
+    end
+
+    context 'when Apollo Local is available and has delete_by_tags' do
+      let(:mock_store) do
+        double('ApolloLocal', started?: true).tap do |s|
+          allow(s).to receive(:respond_to?).with(:delete_by_tags).and_return(true)
+          allow(s).to receive(:delete_by_tags)
+            .with(tags: %w[self-knowledge attribution partner:X])
+            .and_return({ success: true, count: 3 })
+        end
+      end
+
+      before do
+        stub_const('Legion::Apollo::Local', mock_store)
+      end
+
+      it 'delegates to store.delete_by_tags and returns count' do
+        result = described_class.erase_attribution!(identity: 'X')
+        expect(result).to include(erased: true, identity: 'X', count: 3)
+      end
+    end
+  end
+
   describe 'VERSION' do
     it 'has a version number' do
       expect(Legion::Gaia::VERSION).not_to be_nil


### PR DESCRIPTION
## Summary
- Add `BondRegistry.erase_partner!(identity:)` to delete a single bond entry
- Add `Gaia.erase_attribution!(identity:)` for Apollo local attribution record cleanup
- Prep for H8 death protocol cascade — these were gaps found in Phase 4.5 contract gate

## Test plan
- [ ] `bundle exec rspec` passes (0 failures)
- [ ] `bundle exec rubocop` passes (0 offenses)
- [ ] BondRegistry erase specs: selective delete, idempotent, event emission
- [ ] Attribution erasure specs

Part of #43
Part of #36